### PR TITLE
Fix parameter order

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -66,7 +66,7 @@ exports.create = function(options, callback) {
 
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-    conditions[0].setAttribute('NotOnOrAfter', now.add('seconds', options.lifetimeInSeconds).format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+    conditions[0].setAttribute('NotOnOrAfter', now.add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
   
   if (options.audiences) {

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -67,9 +67,9 @@ exports.create = function(options, callback) {
 
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-    conditions[0].setAttribute('NotOnOrAfter', now.clone().add('seconds', options.lifetimeInSeconds).format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+    conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds,'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add('seconds', options.lifetimeInSeconds).format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
   }
   
   if (options.audiences) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saml",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "devDependencies": {
     "mocha": "*",
     "should": "~1.2.1"


### PR DESCRIPTION
```
Deprecation warning: moment().add(period, number) is deprecated. Please use moment().add(number, period). See http://momentjs.com/guides/#/warnings/add-inverted-param/ for more info.
```

When the moment library was upgraded, this warning started appearing. This change updates the use of the library so that the warning disappears.
