### PR TITLE
Specify the correct xsi:type for each attribute

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -22,6 +22,19 @@ var algorithms = {
   }
 };
 
+function getType(value){
+  switch (typeof value){
+    case 'boolean':
+      return 'xs:boolean';
+    case 'number':
+      return 'xs:long';
+    case 'string':
+      return 'xs:string';
+    default:
+      return 'xs:anyType';     
+  }
+}
+
 exports.create = function(options, callback) {
   if (!options.key)
     throw new Error('Expect a private key in pem format');
@@ -100,7 +113,7 @@ exports.create = function(options, callback) {
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
       values.forEach(function (value) {
         var valueElement = doc.createElementNS(NAMESPACE, 'saml:AttributeValue');
-        valueElement.setAttribute('xsi:type', 'xs:anyType');
+        valueElement.setAttribute('xsi:type', getType(value));
         valueElement.textContent = value;
         attributeElement.appendChild(valueElement);
       });

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -65,7 +65,9 @@ describe('saml 2.0', function () {
         'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
         'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
         'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
+        'http://undefinedattribute/ws/com.com': undefined,
+        'http://example.org/claims/booleanprop': true,
+        'http://example.org/claims/numberprop': 1
       }
     };
 
@@ -75,13 +77,22 @@ describe('saml 2.0', function () {
     assert.equal(true, isValid);
 
     var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(3, attributes.length);
+    assert.equal(5, attributes.length);
     assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+    assert.equal('xs:string', attributes[0].childNodes[0].getAttribute('xsi:type'));
     assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));  
+    assert.equal('xs:string', attributes[1].childNodes[0].getAttribute('xsi:type'));
     assert.equal('Foo Bar', attributes[1].textContent);
     assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
+    assert.equal('xs:string', attributes[2].childNodes[0].getAttribute('xsi:type'));        
     assert.equal('fóo', attributes[2].textContent);
+    assert.equal('http://example.org/claims/booleanprop', attributes[3].getAttribute('Name'));
+    assert.equal('xs:boolean', attributes[3].childNodes[0].getAttribute('xsi:type'));
+    assert.equal('true', attributes[3].textContent);
+    assert.equal('http://example.org/claims/numberprop', attributes[4].getAttribute('Name'));
+    assert.equal('xs:long', attributes[4].childNodes[0].getAttribute('xsi:type'));    
+    assert.equal('1', attributes[4].textContent);
   });
 
   it('whole thing with specific authnContextClassRef', function () {


### PR DESCRIPTION
Improved SAML Assertion to include the correct xsi:type for each attribute