### PR TITLE
Adds an option to prefix the signature fields with ds:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+sudo: false
 language: node_js
 node_js:
   - 0.8
+  - 4.2.0
+before_install:
+  - npm i -g npm@latest

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -184,7 +184,17 @@ function sign(options, sig, doc, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    sig.computeSignature(token, options.xpathToNodeBeforeSignature);
+
+    var sigOpts = {};
+
+    if (options.xpathToNodeBeforeSignature) {
+      sigOpts.location = {
+        reference: options.xpathToNodeBeforeSignature,
+        action: 'after'
+      };
+    }
+
+    sig.computeSignature(token, sigOpts);
     signed = sig.getSignedXml();
   } catch(err){
     return utils.reportError(err, callback);

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -41,9 +41,14 @@ exports.create = function(options, callback) {
 
   sig.signingKey = options.key;
   
+  var dsPrefix = '';
+  if (options.addDsPrefix) {
+    dsPrefix = 'ds:';
+  }
+
   sig.keyInfoProvider = {
     getKeyInfo: function () {
-      return "<X509Data><X509Certificate>" + cert + "</X509Certificate></X509Data>";
+      return "<" + dsPrefix + "X509Data><" + dsPrefix + "X509Certificate>" + cert + "</" + dsPrefix + "X509Certificate></" + dsPrefix + "X509Data>";
     }
   };
 
@@ -138,8 +143,21 @@ exports.create = function(options, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    sig.computeSignature(token, options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']");
+
+    var sigOpts = {
+      location: {
+        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']",
+        action: 'after'
+      }
+    }
+
+    if (options.addDsPrefix) {
+      sigOpts.prefix = 'ds';
+    }
+
+    sig.computeSignature(token, sigOpts);
     signed = sig.getSignedXml();
+
   } catch(err){
     return utils.reportError(err, callback);
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Matias Woloski (Auth0)",
   "license": "MIT",
   "dependencies": {
-    "xml-crypto": "~0.0.20",
+    "xml-crypto": "~0.8.4",
     "xmldom": "=0.1.15",
     "moment": "~2.14.1",
     "xml-encryption": "~0.7.4",


### PR DESCRIPTION
The SAML v2.0 XSD specifies that the signature fields should be prefixed with ds:

https://docs.oasis-open.org/security/saml/v2.0/saml-schema-protocol-2.0.xsd

I've added an option that adds this prefix to all of the signature fields.
