### PR TITLE
Added nameformat and type for attributes

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -3,7 +3,9 @@ var utils = require('./utils'),
     Parser = require('xmldom').DOMParser,
     SignedXml = require('xml-crypto').SignedXml,
     xmlenc = require('xml-encryption'),
-    moment = require('moment');
+    moment = require('moment'),
+    xmlNameValidator = require('xml-name-validator'),
+    is_uri = require('valid-url').is_uri;
 
 var fs = require('fs');
 var path = require('path');
@@ -22,6 +24,37 @@ var algorithms = {
   }
 };
 
+function getAttributeType(value){
+  switch(typeof value) {
+    case "string":
+      return 'xs:string';
+    case "boolean":
+      return 'xs:boolean';
+    case "number":
+      // Maybe we should fine-grain this type and check whether it is an integer, float, double xsi:types
+      return 'xs:double';
+    default:
+      return 'xs:anyType';
+  }
+}
+
+function getNameFormat(name){
+  if (is_uri(name)){
+    return 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri';
+  }
+
+  //  Check that the name is a valid xs:Name -> https://www.w3.org/TR/xmlschema-2/#Name
+  //  xmlNameValidate.name takes a string and will return an object of the form { success, error }, 
+  //  where success is a boolean 
+  //  if it is false, then error is a string containing some hint as to where the match went wrong.
+  if (xmlNameValidator.name(name).success){
+    return 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic';
+  }
+
+  // Default value
+  return 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified';
+}
+
 exports.create = function(options, callback) {
   if (!options.key)
     throw new Error('Expect a private key in pem format');
@@ -31,6 +64,10 @@ exports.create = function(options, callback) {
 
   options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
   options.digestAlgorithm = options.digestAlgorithm || 'sha256';
+
+  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
+  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
+
 
   var cert = utils.pemToCert(options.cert);
 
@@ -97,15 +134,24 @@ exports.create = function(options, callback) {
       // </saml:Attribute>
       var attributeElement = doc.createElementNS(NAMESPACE, 'saml:Attribute');
       attributeElement.setAttribute('Name', prop);
+
+      if (options.includeAttributeNameFormat){
+        attributeElement.setAttribute('NameFormat', getNameFormat(prop));        
+      }
+
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
       values.forEach(function (value) {
-        var valueElement = doc.createElementNS(NAMESPACE, 'saml:AttributeValue');
-        valueElement.setAttribute('xsi:type', 'xs:anyType');
-        valueElement.textContent = value;
-        attributeElement.appendChild(valueElement);
+        // Check by type, becase we want to include false values
+        if (typeof value !== 'undefined') {
+          // Ignore undefined values in Array
+          var valueElement = doc.createElementNS(NAMESPACE, 'saml:AttributeValue');
+          valueElement.setAttribute('xsi:type', options.typedAttributes ? getAttributeType(value) : 'xs:anyType');
+          valueElement.textContent = value;
+          attributeElement.appendChild(valueElement);
+        }
       });
 
-      if (values && values.length > 0) {
+      if (values && values.filter(function(i){ return typeof i !== 'undefined'; }).length > 0) {
         // saml:Attribute must have at least one saml:AttributeValue
         statement.appendChild(attributeElement);
       }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "async": "~0.2.9",
     "moment": "~2.14.1",
+    "valid-url": "~1.0.9",
     "xml-crypto": "0.8.4",
     "xml-encryption": "~0.7.4",
+    "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",
     "xpath": "0.0.5"
   },


### PR DESCRIPTION
Included two new options:

- `options.includeAttributeNameFormat` (default: `true`) to infer the NameFormat based on the Name of the attribute.
-  `options.typedAttributes` (default: `true`) to set the xs:type based on the attribute value javascript type.