### PR TITLE
Upgrade xml-crypto library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.12
+  - 4.4.3

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -183,8 +183,16 @@ function addSubjectConfirmation(options, doc, randomBytes, callback) {
 function sign(options, sig, doc, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
+
   try {
-    sig.computeSignature(token, options.xpathToNodeBeforeSignature);
+    var opts = options.xpathToNodeBeforeSignature ? { 
+      location: { 
+        reference: options.xpathToNodeBeforeSignature, 
+        action: 'after'
+      }
+    } : {};
+
+    sig.computeSignature(token, opts);
     signed = sig.getSignedXml();
   } catch(err){
     return utils.reportError(err, callback);

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -138,7 +138,14 @@ exports.create = function(options, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    sig.computeSignature(token, options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']");
+    var opts = { 
+      location: { 
+        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
+        action: 'after'
+      }
+    };
+    
+    sig.computeSignature(token, opts);
     signed = sig.getSignedXml();
   } catch(err){
     return utils.reportError(err, callback);

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   "author": "Matias Woloski (Auth0)",
   "license": "MIT",
   "dependencies": {
-    "xml-crypto": "~0.0.20",
-    "xmldom": "=0.1.15",
+    "async": "~0.2.9",
     "moment": "~2.14.1",
+    "xml-crypto": "0.8.4",
     "xml-encryption": "~0.7.4",
-    "xpath": "0.0.5",
-    "async": "~0.2.9"
+    "xmldom": "=0.1.15",
+    "xpath": "0.0.5"
   },
   "scripts": {
     "test": "mocha"

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -230,22 +230,7 @@ describe('saml 1.1', function () {
     assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', format);
   });
 
-
-it('should override AttirubteStatement NameFormat', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo',
-      nameIdentifierFormat: 'http://foo'
-    };
-    var signedAssertion = saml11.create(options);
-    var format = utils.getNameIdentifier(signedAssertion)
-                              .getAttribute('Format');
-    assert.equal('http://foo', format);
-  });
-
-
-it('should override AttirubteStatement NameFormat', function () {
+  it('should override AttirubteStatement NameFormat', function () {
     var options = {
       cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
       key: fs.readFileSync(__dirname + '/test-auth0.key'),
@@ -273,8 +258,6 @@ it('should override AttirubteStatement NameFormat', function () {
 
     assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
   });
-
-
 
   it('should test the whole thing', function () {
     var options = {

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -132,6 +132,31 @@ describe('saml 2.0', function () {
     assert.equal('specific', authnContextClassRef.textContent);
   });
 
+  it('should place signature where specified', function () {
+     var options = {
+      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+      key: fs.readFileSync(__dirname + '/test-auth0.key'),
+      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+      attributes: {
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+        'http://example.org/claims/testaccent': 'fóo', // should supports accents
+        'http://undefinedattribute/ws/com.com': undefined
+      }
+    };
+
+    var signedAssertion = saml.create(options);
+    
+    var isValid = utils.isValidSignature(signedAssertion, options.cert);
+    assert.equal(true, isValid);
+    
+    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+    var signature = doc.documentElement.getElementsByTagName('Signature');
+
+    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+  });
+
   describe('encryption', function () {
 
     it('should create a saml 2.0 signed and encrypted assertion', function (done) {


### PR DESCRIPTION
Updated xml-crypto library to the latest version. This update fixes an issue when the SAML Assertion contains special characters (e.g. `"`)

The change required in xml-crypto is https://github.com/yaronn/xml-crypto/pull/99 which is included in version 0.8.4