### PR TITLE
only include AttributeStatement if attributes are specified in options

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -132,7 +132,10 @@ exports.create = function(options, callback) {
     confirmationData[0].setAttribute('InResponseTo', options.inResponseTo);
 
   if (options.attributes) {
-    var statement = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'AttributeStatement')[0];
+    var statement = doc.createElementNS(NAMESPACE, 'AttributeStatement');
+    statement.setAttribute('xmlns:xs', 'http://www.w3.org/2001/XMLSchema');
+    statement.setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+    doc.documentElement.appendChild(statement);
     Object.keys(options.attributes).forEach(function(prop) {
       if(typeof options.attributes[prop] === 'undefined') return;
       // <saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/claims/identity">

--- a/lib/saml20.template
+++ b/lib/saml20.template
@@ -7,7 +7,6 @@
     </saml:SubjectConfirmation>
   </saml:Subject>
   <saml:Conditions />
-  <saml:AttributeStatement xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" />
   <saml:AuthnStatement AuthnInstant="">
     <saml:AuthnContext>
       <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml:AuthnContextClassRef>

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -465,6 +465,23 @@ describe('saml 2.0', function () {
     assert.equal(audienceRestriction.length, 0);
   });
 
+  it('should not include AttributeStatement when there are no attributes', function () {
+    var options = {
+      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+      key: fs.readFileSync(__dirname + '/test-auth0.key'),
+      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+      signatureNamespacePrefix: 123
+    };
+
+    var signedAssertion = saml.create(options);
+
+    var isValid = utils.isValidSignature(signedAssertion, options.cert);
+    assert.equal(true, isValid);
+
+    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+    var attributeStatement = doc.documentElement.getElementsByTagName('saml:AttributeStatement');
+    assert.equal(attributeStatement.length, 0);
+  });
 
   describe('encryption', function () {
 


### PR DESCRIPTION
Thanks for this module first of all!

I'm working with a client in which they need to create a SOAP call with a SAML assertion inserted in the WS-Security header. This package works great except that the request I need to make does not contain any `Attributes` and the system receiving the SOAP request rejects it if there is an empty `AttributeStatement` element. This change creates the `AttributeStatement` element only if there are `Attributes` defined in the options.