### PR TITLE
pinned mocha to ^3 [resolves #34]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saml",
   "version": "0.12.4",
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "^3.0.0-2",
     "should": "~1.2.1"
   },
   "main": "./lib",


### PR DESCRIPTION
Mocha version 4 (released in October) drops support for Node version 0.12, which is specified in the .travis.yml file.

resolves #34 