### PR TITLE
Upgrade moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "~0.2.9",
-    "moment": "2.15.2",
+    "moment": "^2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "~0.10.1",
     "xml-encryption": "0.11.0",


### PR DESCRIPTION
Fixes #38

Upgrades moment to 2.19.3 and loosens its version requirement to allow consumers to auto upgrade in the future.

The last time the moment version was changed was also for a vulnerability, https://github.com/spalger/node-saml/commit/203e07728ad3315b6bad124cbf6d40140e5d5f86, so using a looser version requirement should allow users to upgrade moment without requiring updates to node-samle in the future, when new vulnerabilities are discovered.