### PR TITLE
Add a keyInfoProvider option to support use of <RetrivalMethod>

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -81,7 +81,7 @@ exports.create = function(options, callback) {
 
   sig.signingKey = options.key;
   
-  sig.keyInfoProvider = {
+  sig.keyInfoProvider = options.keyInfoProvider || {
     getKeyInfo: function (key, prefix) {
       prefix = prefix ? prefix + ':' : prefix;
       return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";


### PR DESCRIPTION
The SAML spec allows for use of a <RetrivalMethod> element in lieu of embedding an X509 certificate in the assertion. Add an option t.o support using a <RetrivalMethod>.
