### PR TITLE
Avoiding invalid SAML format when no attributes are given

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -44,8 +44,8 @@ function getNameFormat(name){
   }
 
   //  Check that the name is a valid xs:Name -> https://www.w3.org/TR/xmlschema-2/#Name
-  //  xmlNameValidate.name takes a string and will return an object of the form { success, error }, 
-  //  where success is a boolean 
+  //  xmlNameValidate.name takes a string and will return an object of the form { success, error },
+  //  where success is a boolean
   //  if it is false, then error is a string containing some hint as to where the match went wrong.
   if (xmlNameValidator.name(name).success){
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic';
@@ -70,7 +70,7 @@ exports.create = function(options, callback) {
 
   // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
   options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
+  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ;
 
   var cert = utils.pemToCert(options.cert);
 
@@ -80,7 +80,7 @@ exports.create = function(options, callback) {
                   algorithms.digest[options.digestAlgorithm]);
 
   sig.signingKey = options.key;
-  
+
   sig.keyInfoProvider = {
     getKeyInfo: function (key, prefix) {
       prefix = prefix ? prefix + ':' : prefix;
@@ -109,10 +109,10 @@ exports.create = function(options, callback) {
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-  
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
+
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
-  
+
   if (options.audiences) {
     var audienceRestriction = doc.createElementNS(NAMESPACE, 'saml:AudienceRestriction');
     var audiences = options.audiences instanceof Array ? options.audiences : [options.audiences];
@@ -122,7 +122,7 @@ exports.create = function(options, callback) {
       audienceRestriction.appendChild(element);
     });
 
-    conditions[0].appendChild(audienceRestriction); 
+    conditions[0].appendChild(audienceRestriction);
   }
 
   if (options.recipient)
@@ -131,7 +131,7 @@ exports.create = function(options, callback) {
   if (options.inResponseTo)
     confirmationData[0].setAttribute('InResponseTo', options.inResponseTo);
 
-  if (options.attributes) {
+  if (options.attributes && Object.keys(options.attributes).length) {
     var statement = doc.createElementNS(NAMESPACE, 'saml:AttributeStatement');
     statement.setAttribute('xmlns:xs', 'http://www.w3.org/2001/XMLSchema');
     statement.setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
@@ -145,7 +145,7 @@ exports.create = function(options, callback) {
       attributeElement.setAttribute('Name', prop);
 
       if (options.includeAttributeNameFormat){
-        attributeElement.setAttribute('NameFormat', getNameFormat(prop));        
+        attributeElement.setAttribute('NameFormat', getNameFormat(prop));
       }
 
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
@@ -165,6 +165,9 @@ exports.create = function(options, callback) {
         statement.appendChild(attributeElement);
       }
     });
+  } else {
+    var statement = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'AttributeStatement')[0];
+    statement.parentNode.removeChild(statement);
   }
 
   doc.getElementsByTagName('saml:AuthnStatement')[0]
@@ -176,7 +179,7 @@ exports.create = function(options, callback) {
   }
 
   var nameID = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameID')[0];
-  
+
   if (options.nameIdentifier) {
     nameID.textContent = options.nameIdentifier;
   }
@@ -184,7 +187,7 @@ exports.create = function(options, callback) {
   if (options.nameIdentifierFormat) {
     nameID.setAttribute('Format', options.nameIdentifierFormat);
   }
-  
+
   if( options.authnContextClassRef ) {
     var authnCtxClassRef = doc.getElementsByTagName('saml:AuthnContextClassRef')[0];
     authnCtxClassRef.textContent = options.authnContextClassRef;
@@ -193,14 +196,14 @@ exports.create = function(options, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    var opts = { 
-      location: { 
-        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
+    var opts = {
+      location: {
+        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']",
         action: 'after'
       },
       prefix: options.signatureNamespacePrefix
     };
-    
+
     sig.computeSignature(token, opts);
     signed = sig.getSignedXml();
   } catch(err){
@@ -208,9 +211,9 @@ exports.create = function(options, callback) {
   }
 
   if (!options.encryptionCert) {
-    if (callback) 
+    if (callback)
       return callback(null, signed);
-    else 
+    else
       return signed;
   }
 
@@ -227,5 +230,5 @@ exports.create = function(options, callback) {
     encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
     callback(null, utils.removeWhitespace(encrypted));
   });
-}; 
+};
 


### PR DESCRIPTION
If no attributes are given, resulting in an invalid assertion due to an empty AttributeStatement. Removing the AttributeStatement node makes the assertion format valid.

Not knowing a lot about SAML, I came to this conclusion by using this tool: https://www.samltool.com/validate_xml.php

Fixes #33