### PR TITLE
chore - updating xml-encryption to 0.11.2 to resolve licensing issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saml",
   "version": "0.12.4",
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "3.5.3",
     "should": "~1.2.1"
   },
   "main": "./lib",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "moment": "2.15.2",
     "valid-url": "~1.0.9",
     "xml-crypto": "~0.10.1",
-    "xml-encryption": "0.11.0",
+    "xml-encryption": "0.11.2",
     "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",
     "xpath": "0.0.5"


### PR DESCRIPTION
This is to get the new version of `xml-encryption` that resolved https://github.com/auth0/node-xml-encryption/issues/43 and https://github.com/auth0/node-xml-encryption/pull/44.