### PR TITLE
Use xml-crypto@1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "~0.2.9",
     "moment": "2.15.2",
     "valid-url": "~1.0.9",
-    "xml-crypto": "~0.10.1",
+    "xml-crypto": "~1.0.1",
     "xml-encryption": "0.11.2",
     "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",


### PR DESCRIPTION
A new release of xml-crypto was made, delivering several bugfixes (notably now allowing double-signing of responses). Despite the major version change, API and behaviour should remain largely the same