### PR TITLE
Use xml-crypto@1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "~0.2.9",
     "moment": "2.15.2",
     "valid-url": "~1.0.9",
-    "xml-crypto": "~1.0.1",
+    "xml-crypto": "~1.1.1",
     "xml-encryption": "0.11.2",
     "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",


### PR DESCRIPTION
This release of xml-crypto drops xpath.js in favour of xpath,
which is more actively maintained