### PR TITLE
Add maxClockSkewInSeconds for NotBefore value (default is 0)

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -102,12 +102,14 @@ exports.create = function(options, callback) {
   }
 
   var now = moment.utc();
+  var maxClockSkew = options.maxClockSkewInSeconds || 0
+  var notBefore = now.clone().subtract(maxClockSkew, 'seconds')
   doc.documentElement.setAttribute('IssueInstant', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   var conditions = doc.documentElement.getElementsByTagName('saml:Conditions');
   var confirmationData = doc.documentElement.getElementsByTagName('saml:SubjectConfirmationData');
 
   if (options.lifetimeInSeconds) {
-    conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+    conditions[0].setAttribute('NotBefore', notBefore.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   
     confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  


### PR DESCRIPTION
Distributed authentication systems depend on clock synchronziation between servers. Some amount of time is needed to compensate time discrepancies between IdP and SP.
_maxClockSkewInSeconds_ can be passed in options, indicating the maximum allowed time difference between the servers. It will be subtracted from _now_, and then the new value will be used as NotBefore time.