### PR TITLE
SAML assertion signing using HSM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+package-lock.json

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -74,7 +74,13 @@ exports.create = function(options, callback) {
 
   var cert = utils.pemToCert(options.cert);
 
-  var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
+  var signatureAlgorithm = algorithms.signature[options.signatureAlgorithm];
+  if (typeof (options.signatureFunction) === 'function') {
+    signatureAlgorithm = (new options.signatureFunction()).getAlgorithmName();
+    SignedXml.SignatureAlgorithms[signatureAlgorithm] = options.signatureFunction;
+  }
+  var sig = new SignedXml(null, { signatureAlgorithm: signatureAlgorithm, idAttribute: 'ID'});
+
   sig.addReference("//*[local-name(.)='Assertion']",
                   ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
                   algorithms.digest[options.digestAlgorithm]);
@@ -200,32 +206,39 @@ exports.create = function(options, callback) {
       },
       prefix: options.signatureNamespacePrefix
     };
-    
-    sig.computeSignature(token, opts);
-    signed = sig.getSignedXml();
+
+    if (callback) {
+      sig.computeSignature(token, opts, function(err, sigXML){
+        if (err || !sigXML) return callback(err)
+        signed = sigXML.getSignedXml();
+
+        if (!options.encryptionCert) {
+          return callback(null, signed);
+        }
+
+        var encryptOptions = {
+          rsa_pub: options.encryptionPublicKey,
+          pem: options.encryptionCert,
+          encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+          keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+        };
+
+        xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
+          if (err) return callback(err);
+          encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+          callback(null, utils.removeWhitespace(encrypted));
+        });
+      });
+    } else {
+      sig.computeSignature(token, opts);
+      signed = sig.getSignedXml();
+
+      if (!options.encryptionCert) {
+        return signed;
+      }
+    }
   } catch(err){
     return utils.reportError(err, callback);
   }
-
-  if (!options.encryptionCert) {
-    if (callback) 
-      return callback(null, signed);
-    else 
-      return signed;
-  }
-
-
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
-    if (err) return callback(err);
-    encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-    callback(null, utils.removeWhitespace(encrypted));
-  });
 }; 
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "async": "~0.2.9",
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
-    "xml-crypto": "~1.0.1",
+    "xml-crypto": "~1.5.3",
     "xml-encryption": "0.11.2",
     "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",


### PR DESCRIPTION
### Description
Using an HSM or signing server for assertion signing is the most secure way to store private keys. These transactions typically need to take place over an asynchronous connection.

Added support for asynchronous XML signing using custom functions provided by the host application. I have created the relevant PR to xml-crypto and those have been published in xml-crypto@1.5.3

### References
Fixes #63 

### Testing
Unit tests have been created using async XML signing and a custom signing function.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
