### PR TITLE
feat: adds saml.createUnsignedAssertion()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-Create SAML assertions.
+# node-saml
 
-NOTE: currently supports SAML 1.1 tokens
+Create SAML assertions. Supports SAML 1.1 and SAML 2.0 tokens.
 
 [![Build Status](https://travis-ci.org/auth0/node-saml.png)](https://travis-ci.org/auth0/node-saml)
 
 ### Usage
 
 ```js
-var saml11 = require('saml').Saml11;
+var saml = require('saml').Saml20; // or Saml11
 
 var options = {
   cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
@@ -23,7 +23,7 @@ var options = {
   sessionIndex: '_faed468a-15a0-4668-aed6-3d9c478cc8fa'
 };
 
-var signedAssertion = saml11.create(options);
+var signedAssertion = saml.create(options);
 ```
 
 Everything except the cert and key is optional.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -1,53 +1,23 @@
-
-var utils = require('./utils'),
-    Parser = require('xmldom').DOMParser,
-    SignedXml = require('xml-crypto').SignedXml,
-    xmlenc = require('xml-encryption'),
-    moment = require('moment');
-    async = require('async');
-    crypto = require('crypto');
-
 var fs = require('fs');
 var path = require('path');
+var utils = require('./utils');
+var Parser = require('xmldom').DOMParser;
+var xmlenc = require('xml-encryption');
+var moment = require('moment');
+var async = require('async');
+var crypto = require('crypto');
+
+var SignXml = require('./xml/sign');
+
 var saml11 = fs.readFileSync(path.join(__dirname, 'saml11.template')).toString();
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:1.0:assertion';
 
-var algorithms = {
-  signature: {
-    'rsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-    'rsa-sha1':  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
-  },
-  digest: {
-    'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
-    'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1'
-  }
-};
-
 exports.create = function(options, callback) {
-  if (!options.key)
-    throw new Error('Expect a private key in pem format');
-
-  if (!options.cert)
-    throw new Error('Expect a public key cert in pem format');
-
-  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
-  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
-
-  var cert = utils.pemToCert(options.cert);
-
-  var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'AssertionID' });
-  sig.addReference("//*[local-name(.)='Assertion']",
-                  ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-                  algorithms.digest[options.digestAlgorithm]);
-
-  sig.signingKey = options.key;
-  
-  sig.keyInfoProvider = {
-    getKeyInfo: function () {
-      return "<X509Data><X509Certificate>" + cert + "</X509Certificate></X509Data>";
-    }
-  };
+  var signXml = SignXml.fromSignXmlOptions(Object.assign({
+    xpathToNodeBeforeSignature: "//*[local-name(.)='AuthenticationStatement']",
+    signatureIdAttribute: 'AssertionID'
+  }, options));
 
   var doc;
   try {
@@ -125,7 +95,7 @@ exports.create = function(options, callback) {
     nameIDs[1].setAttribute('Format', options.nameIdentifierFormat);
   }
 
-  if (!options.encryptionCert) return sign(options, sig, doc, callback);
+  if (!options.encryptionCert) return signXml(doc, callback);
 
   // encryption is turned on, 
   var proofSecret;
@@ -141,7 +111,7 @@ exports.create = function(options, callback) {
       
     },
     function(cb) {
-      sign(options, sig, doc, function(err, signed) {
+      signXml(doc, function(err, signed) {
         if (err) return cb(err);
         return encrypt(options, signed, cb);
       });
@@ -178,29 +148,6 @@ function addSubjectConfirmation(options, doc, randomBytes, callback) {
 
     callback();
   });
-}
-
-function sign(options, sig, doc, callback) {
-  var token = utils.removeWhitespace(doc.toString());
-  var signed;
-
-  try {
-    var opts = options.xpathToNodeBeforeSignature ? { 
-      location: { 
-        reference: options.xpathToNodeBeforeSignature, 
-        action: 'after'
-      }
-    } : {};
-
-    sig.computeSignature(token, opts);
-    signed = sig.getSignedXml();
-  } catch(err){
-    return utils.reportError(err, callback);
-  }
-
-  if (!callback) return signed;
-
-  return callback(null, signed);
 }
 
 function encrypt(options, signed, callback) {

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -70,6 +70,36 @@ exports.create = function(options, callback) {
   }, callback);
 }
 
+/**
+ * Creates an **unsigned** SAML 1.1 assertion from the given options.
+ *
+ * @param options
+ *
+ * // SAML
+ * @param [options.uid] {string}
+ * @param [options.issuer] {string}
+ * @param [options.lifetimeInSeconds] {number}
+ * @param [options.audiences] {string|string[]}
+ * @param [options.attributes]
+ * @param [options.nameIdentifier] {string}
+ * @param [options.nameIdentifierFormat] {string}
+ *
+ * // XML encryption
+ * @param [options.encryptionCert] {Buffer}
+ * @param [options.encryptionPublicKey] {Buffer}
+ * @param [options.encryptionAlgorithm] {string}
+ * @param [options.keyEncryptionAlgorighm] {string}
+ *
+ * @param {Function} [callback] required if encrypting
+ * @return {String|*}
+ */
+exports.createUnsignedAssertion = function(options, callback) {
+  return createAssertion(extractSaml11Options(options), {
+    signXml: SignXml.unsigned,
+    encryptXml: EncryptXml.fromEncryptXmlOptions(options)
+  }, callback);
+}
+
 function createAssertion(options, strategies, callback) {
   var doc;
   try {

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 var path = require('path');
 var utils = require('./utils');
 var Parser = require('xmldom').DOMParser;
@@ -10,7 +9,7 @@ var crypto = require('crypto');
 var EncryptXml = require('./xml/encrypt');
 var SignXml = require('./xml/sign');
 
-var saml11 = fs.readFileSync(path.join(__dirname, 'saml11.template')).toString();
+var newSaml11Document = utils.factoryForNode(path.join(__dirname, 'saml11.template'));
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:1.0:assertion';
 
@@ -74,7 +73,7 @@ exports.create = function(options, callback) {
 function createAssertion(options, strategies, callback) {
   var doc;
   try {
-    doc = new Parser().parseFromString(saml11.toString());
+    doc = newSaml11Document();
   } catch(err){
     return utils.reportError(err, callback);
   }

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -7,6 +7,7 @@ var moment = require('moment');
 var async = require('async');
 var crypto = require('crypto');
 
+var EncryptXml = require('./xml/encrypt');
 var SignXml = require('./xml/sign');
 
 var saml11 = fs.readFileSync(path.join(__dirname, 'saml11.template')).toString();
@@ -175,39 +176,6 @@ function createAssertion(options, strategies, callback) {
     callback(null, result, proofSecret);
   });
 }
-
-var EncryptXml = Object.freeze({
-  fromEncryptXmlOptions: function (options) {
-    if (!options.encryptionCert) {
-      return this.unencrypted;
-    } else {
-      var encryptOptions = {
-        rsa_pub: options.encryptionPublicKey,
-        pem: options.encryptionCert,
-        encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-        keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
-      };
-
-      // expose the encryptOptions as these are needed when adding the SubjectConfirmation
-      return Object.assign(this.encrypted(encryptOptions), { encryptOptions: encryptOptions });
-    }
-  },
-  unencrypted: function (xml, callback) {
-    if (callback) {
-      setImmediate(callback, null, xml);
-    } else {
-      return xml;
-    }
-  },
-  encrypted: function (encryptOptions) {
-    return function encrypt(xml, callback) {
-      xmlenc.encrypt(xml, encryptOptions, function (err, encrypted) {
-        if (err) return callback(err);
-        callback(null, utils.removeWhitespace(encrypted));
-      });
-    };
-  }
-})
 
 function addSubjectConfirmation(encryptOptions, doc, randomBytes, callback) {
   xmlenc.encryptKeyInfo(randomBytes, encryptOptions, function(err, keyinfo) {

--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -13,12 +13,64 @@ var saml11 = fs.readFileSync(path.join(__dirname, 'saml11.template')).toString()
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:1.0:assertion';
 
-exports.create = function(options, callback) {
-  var signXml = SignXml.fromSignXmlOptions(Object.assign({
-    xpathToNodeBeforeSignature: "//*[local-name(.)='AuthenticationStatement']",
-    signatureIdAttribute: 'AssertionID'
-  }, options));
+function extractSaml11Options(opts) {
+  return {
+    uid: opts.uid,
+    issuer: opts.issuer,
+    lifetimeInSeconds: opts.lifetimeInSeconds,
+    audiences: opts.audiences,
+    attributes: opts.attributes,
+    nameIdentifier: opts.nameIdentifier,
+    nameIdentifierFormat: opts.nameIdentifierFormat,
+    subjectConfirmationMethod: opts.subjectConfirmationMethod,
+    holderOfKeyProofSecret: opts.holderOfKeyProofSecret
+  };
+}
 
+/**
+ * Creates a signed SAML 1.1 assertion from the given options.
+ *
+ * @param options
+ *
+ * // SAML
+ * @param [options.uid] {string}
+ * @param [options.issuer] {string}
+ * @param [options.lifetimeInSeconds] {number}
+ * @param [options.audiences] {string|string[]}
+ * @param [options.attributes]
+ * @param [options.nameIdentifier] {string}
+ * @param [options.nameIdentifierFormat] {string}
+ *
+ * // XML Dsig
+ * @param options.key {Buffer}
+ * @param options.cert {Buffer}
+ * @param [options.signatureAlgorithm] {string}
+ * @param [options.digestAlgorithm] {string}
+ * @param [options.signatureNamespacePrefix] {string}
+ * @param [options.xpathToNodeBeforeSignature] {string}
+ * @param [options.subjectConfirmationMethod] {string}
+ * @param [options.holderOfKeyProofSecret] {Buffer}
+ *
+ * // XML encryption
+ * @param [options.encryptionCert] {Buffer}
+ * @param [options.encryptionPublicKey] {Buffer}
+ * @param [options.encryptionAlgorithm] {string}
+ * @param [options.keyEncryptionAlgorighm] {string}
+ *
+ * @param {Function} [callback] required if encrypting
+ * @return {String|*}
+ */
+exports.create = function(options, callback) {
+  return createAssertion(extractSaml11Options(options), {
+    signXml: SignXml.fromSignXmlOptions(Object.assign({
+      xpathToNodeBeforeSignature: "//*[local-name(.)='AuthenticationStatement']",
+      signatureIdAttribute: 'AssertionID'
+    }, options)),
+    encryptXml: EncryptXml.fromEncryptXmlOptions(options)
+  }, callback);
+}
+
+function createAssertion(options, strategies, callback) {
   var doc;
   try {
     doc = new Parser().parseFromString(saml11.toString());
@@ -95,42 +147,71 @@ exports.create = function(options, callback) {
     nameIDs[1].setAttribute('Format', options.nameIdentifierFormat);
   }
 
-  if (!options.encryptionCert) return signXml(doc, callback);
+  if (strategies.encryptXml === EncryptXml.unencrypted) {
+    var signed = strategies.signXml(doc);
+    return strategies.encryptXml(signed, callback);
+  }
 
-  // encryption is turned on, 
+  // encryption is turned on,
   var proofSecret;
   async.waterfall([
-    function(cb) {
-      if (!options.subjectConfirmationMethod && options.subjectConfirmationMethod !== 'holder-of-key') 
+    function (cb) {
+      if (!options.subjectConfirmationMethod && options.subjectConfirmationMethod !== 'holder-of-key')
         return cb();
-      
+
       crypto.randomBytes(32, function(err, randomBytes) {
         proofSecret = randomBytes;
-        addSubjectConfirmation(options, doc, options.holderOfKeyProofSecret || randomBytes, cb);
+        addSubjectConfirmation(strategies.encryptXml.encryptOptions, doc, options.holderOfKeyProofSecret || randomBytes, cb);
       });
-      
     },
     function(cb) {
-      signXml(doc, function(err, signed) {
-        if (err) return cb(err);
-        return encrypt(options, signed, cb);
-      });
+      strategies.signXml(doc, cb);
+    },
+    function(signed, cb) {
+      strategies.encryptXml(signed, cb);
     }
-  ], function(err, result) {
+  ], function (err, result) {
     if (err) return callback(err);
     callback(null, result, proofSecret);
   });
-}; 
+}
 
-function addSubjectConfirmation(options, doc, randomBytes, callback) {
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
+var EncryptXml = Object.freeze({
+  fromEncryptXmlOptions: function (options) {
+    if (!options.encryptionCert) {
+      return this.unencrypted;
+    } else {
+      var encryptOptions = {
+        rsa_pub: options.encryptionPublicKey,
+        pem: options.encryptionCert,
+        encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+        keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+      };
 
-  xmlenc.encryptKeyInfo(randomBytes, encryptOptions, function(err, keyinfo) { 
-    if (err) return cb(err);
+      // expose the encryptOptions as these are needed when adding the SubjectConfirmation
+      return Object.assign(this.encrypted(encryptOptions), { encryptOptions: encryptOptions });
+    }
+  },
+  unencrypted: function (xml, callback) {
+    if (callback) {
+      setImmediate(callback, null, xml);
+    } else {
+      return xml;
+    }
+  },
+  encrypted: function (encryptOptions) {
+    return function encrypt(xml, callback) {
+      xmlenc.encrypt(xml, encryptOptions, function (err, encrypted) {
+        if (err) return callback(err);
+        callback(null, utils.removeWhitespace(encrypted));
+      });
+    };
+  }
+})
+
+function addSubjectConfirmation(encryptOptions, doc, randomBytes, callback) {
+  xmlenc.encryptKeyInfo(randomBytes, encryptOptions, function(err, keyinfo) {
+    if (err) return callback(err);
     var subjectConfirmationNodes = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'SubjectConfirmation');
 
     for (var i=0; i<subjectConfirmationNodes.length; i++) {
@@ -147,19 +228,5 @@ function addSubjectConfirmation(options, doc, randomBytes, callback) {
     }
 
     callback();
-  });
-}
-
-function encrypt(options, signed, callback) {
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
-    if (err) return callback(err);
-    callback(null, utils.removeWhitespace(encrypted));
   });
 }

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -72,29 +72,31 @@ function extractSaml20Options(opts) {
 var EncryptXml = Object.freeze({
   fromEncryptXmlOptions: function (options) {
     if (!options.encryptionCert) {
-      return function(xml, callback) {
-        if (callback) {
-          return setImmediate(callback, null, xml);
-        } else {
-          return xml;
-        }
-      }
+      return this.unencrypted;
     } else {
-      return function(xml, callback) {
-        var encryptOptions = {
-          rsa_pub: options.encryptionPublicKey,
-          pem: options.encryptionCert,
-          encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-          keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-        };
-
-        xmlenc.encrypt(xml, encryptOptions, function(err, encrypted) {
-          if (err) return callback(err);
-          encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-          callback(null, utils.removeWhitespace(encrypted));
-        });
-      }
+      return this.encrypted({
+        rsa_pub: options.encryptionPublicKey,
+        pem: options.encryptionCert,
+        encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+        keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+      })
     }
+  },
+  unencrypted: function(xml, callback) {
+    if (callback) {
+      return setImmediate(callback, null, xml);
+    } else {
+      return xml;
+    }
+  },
+  encrypted: function (encryptOptions) {
+    return function encrypt(xml, callback) {
+      xmlenc.encrypt(xml, encryptOptions, function(err, encrypted) {
+        if (err) return callback(err);
+        encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+        callback(null, utils.removeWhitespace(encrypted));
+      });
+    };
   }
 });
 

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,14 +1,14 @@
-
-var utils = require('./utils'),
-    Parser = require('xmldom').DOMParser,
-    SignedXml = require('xml-crypto').SignedXml,
-    xmlenc = require('xml-encryption'),
-    moment = require('moment'),
-    xmlNameValidator = require('xml-name-validator'),
-    is_uri = require('valid-url').is_uri;
-
 var fs = require('fs');
 var path = require('path');
+var Parser = require('xmldom').DOMParser;
+var xmlenc = require('xml-encryption');
+var moment = require('moment');
+var xmlNameValidator = require('xml-name-validator');
+var is_uri = require('valid-url').is_uri;
+
+var SignXml = require('./xml/sign');
+var utils = require('./utils');
+
 var newSaml20Document = (function () {
   var saml20Template = fs.readFileSync(path.join(__dirname, 'saml20.template'));
   var prototypeDoc = new Parser().parseFromString(saml20Template.toString())
@@ -19,17 +19,6 @@ var newSaml20Document = (function () {
 })();
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
-
-var algorithms = {
-  signature: {
-    'rsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-    'rsa-sha1':  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
-  },
-  digest: {
-    'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
-    'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1'
-  }
-};
 
 function getAttributeType(value){
   switch(typeof value) {
@@ -79,54 +68,6 @@ function extractSaml20Options(opts) {
     authnContextClassRef: opts.authnContextClassRef
   };
 }
-
-var SignXml = Object.freeze({
-  fromSignXmlOptions: function (options) {
-    if (!options.key)
-      throw new Error('Expect a private key in pem format');
-
-    if (!options.cert)
-      throw new Error('Expect a public key cert in pem format');
-
-    var key = options.key;
-    var pem = options.cert;
-    var signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
-    var digestAlgorithm = options.digestAlgorithm || 'sha256';
-    var signatureNamespacePrefix = (function (prefix) {
-      // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
-      return typeof prefix === 'string' ? prefix : '';
-    } )(options.signatureNamespacePrefix || options.prefix);
-    var xpathToNodeBeforeSignature = options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']";
-
-    return function signXmlAssertion(token) {
-      var cert = utils.pemToCert(pem);
-
-      var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: 'ID' });
-      sig.addReference("//*[local-name(.)='Assertion']",
-        ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-        algorithms.digest[digestAlgorithm]);
-
-      sig.signingKey = key;
-
-      sig.keyInfoProvider = {
-        getKeyInfo: function (key, prefix) {
-          prefix = prefix ? prefix + ':' : prefix;
-          return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
-        }
-      };
-
-      sig.computeSignature(token, {
-        location: { reference: xpathToNodeBeforeSignature, action: 'after' },
-        prefix: signatureNamespacePrefix
-      });
-      return sig.getSignedXml();
-    };
-  },
-
-  unsigned: function (xml) {
-    return xml;
-  }
-});
 
 var EncryptXml = Object.freeze({
   fromEncryptXmlOptions: function (options) {

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,7 +1,5 @@
-var fs = require('fs');
 var path = require('path');
 var async = require('async');
-var Parser = require('xmldom').DOMParser;
 var moment = require('moment');
 var xmlNameValidator = require('xml-name-validator');
 var is_uri = require('valid-url').is_uri;
@@ -10,14 +8,7 @@ var EncryptXml = require('./xml/encrypt');
 var SignXml = require('./xml/sign');
 var utils = require('./utils');
 
-var newSaml20Document = (function () {
-  var saml20Template = fs.readFileSync(path.join(__dirname, 'saml20.template'));
-  var prototypeDoc = new Parser().parseFromString(saml20Template.toString())
-
-  return function () {
-    return prototypeDoc.cloneNode(true);
-  };
-})();
+var newSaml20Document = utils.factoryForNode(path.join(__dirname, 'saml20.template'));
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
 

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -9,7 +9,14 @@ var utils = require('./utils'),
 
 var fs = require('fs');
 var path = require('path');
-var saml20 = fs.readFileSync(path.join(__dirname, 'saml20.template')).toString();
+var newSaml20Document = (function () {
+  var saml20Template = fs.readFileSync(path.join(__dirname, 'saml20.template'));
+  var prototypeDoc = new Parser().parseFromString(saml20Template.toString())
+
+  return function () {
+    return prototypeDoc.cloneNode(true);
+  };
+})();
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
 
@@ -88,12 +95,7 @@ exports.create = function(options, callback) {
     }
   };
 
-  var doc;
-  try {
-    doc = new Parser().parseFromString(saml20.toString());
-  } catch(err){
-    return utils.reportError(err, callback);
-  }
+  var doc = newSaml20Document();
 
   doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
   if (options.issuer) {

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -62,39 +62,190 @@ function getNameFormat(name){
   return 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified';
 }
 
-exports.create = function(options, callback) {
-  if (!options.key)
-    throw new Error('Expect a private key in pem format');
-
-  if (!options.cert)
-    throw new Error('Expect a public key cert in pem format');
-
-  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
-  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
-
-  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
-  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
-
-  // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
-  options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
-
-  var cert = utils.pemToCert(options.cert);
-
-  var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
-  sig.addReference("//*[local-name(.)='Assertion']",
-                  ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-                  algorithms.digest[options.digestAlgorithm]);
-
-  sig.signingKey = options.key;
-  
-  sig.keyInfoProvider = {
-    getKeyInfo: function (key, prefix) {
-      prefix = prefix ? prefix + ':' : prefix;
-      return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
-    }
+function extractSaml20Options(opts) {
+  return {
+    uid: opts.uid,
+    issuer: opts.issuer,
+    lifetimeInSeconds: opts.lifetimeInSeconds,
+    audiences: opts.audiences,
+    recipient: opts.recipient,
+    inResponseTo: opts.inResponseTo,
+    attributes: opts.attributes,
+    includeAttributeNameFormat: (typeof opts.includeAttributeNameFormat !== 'undefined') ? opts.includeAttributeNameFormat : true,
+    typedAttributes: (typeof opts.typedAttributes !== 'undefined') ? opts.typedAttributes : true,
+    sessionIndex: opts.sessionIndex,
+    nameIdentifier: opts.nameIdentifier,
+    nameIdentifierFormat: opts.nameIdentifierFormat,
+    authnContextClassRef: opts.authnContextClassRef
   };
+}
 
+var SignXml = Object.freeze({
+  fromSignXmlOptions: function (options) {
+    if (!options.key)
+      throw new Error('Expect a private key in pem format');
+
+    if (!options.cert)
+      throw new Error('Expect a public key cert in pem format');
+
+    var key = options.key;
+    var pem = options.cert;
+    var signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
+    var digestAlgorithm = options.digestAlgorithm || 'sha256';
+    var signatureNamespacePrefix = (function (prefix) {
+      // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
+      return typeof prefix === 'string' ? prefix : '';
+    } )(options.signatureNamespacePrefix || options.prefix);
+    var xpathToNodeBeforeSignature = options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']";
+
+    return function signXmlAssertion(token) {
+      var cert = utils.pemToCert(pem);
+
+      var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: 'ID' });
+      sig.addReference("//*[local-name(.)='Assertion']",
+        ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
+        algorithms.digest[digestAlgorithm]);
+
+      sig.signingKey = key;
+
+      sig.keyInfoProvider = {
+        getKeyInfo: function (key, prefix) {
+          prefix = prefix ? prefix + ':' : prefix;
+          return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
+        }
+      };
+
+      sig.computeSignature(token, {
+        location: { reference: xpathToNodeBeforeSignature, action: 'after' },
+        prefix: signatureNamespacePrefix
+      });
+      return sig.getSignedXml();
+    };
+  },
+
+  unsigned: function (xml) {
+    return xml;
+  }
+});
+
+var EncryptXml = Object.freeze({
+  fromEncryptXmlOptions: function (options) {
+    if (!options.encryptionCert) {
+      return function(xml, callback) {
+        if (callback) {
+          return setImmediate(callback, null, xml);
+        } else {
+          return xml;
+        }
+      }
+    } else {
+      return function(xml, callback) {
+        var encryptOptions = {
+          rsa_pub: options.encryptionPublicKey,
+          pem: options.encryptionCert,
+          encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+          keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+        };
+
+        xmlenc.encrypt(xml, encryptOptions, function(err, encrypted) {
+          if (err) return callback(err);
+          encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+          callback(null, utils.removeWhitespace(encrypted));
+        });
+      }
+    }
+  }
+});
+
+/**
+ * Creates a signed SAML 2.0 assertion from the given options.
+ *
+ * @param options
+ *
+ * // SAML
+ * @param [options.uid] {string}
+ * @param [options.issuer] {string}
+ * @param [options.lifetimeInSeconds] {number}
+ * @param [options.audiences] {string|string[]}
+ * @param [options.recipient] {string}
+ * @param [options.inResponseTo] {string}
+ * @param [options.attributes]
+ * @param [options.includeAttributeNameFormat] {boolean}
+ * @param [options.typedAttributes] {boolean}
+ * @param [options.sessionIndex] {string}
+ * @param [options.nameIdentifier] {string}
+ * @param [options.nameIdentifierFormat] {string}
+ * @param [options.authnContextClassRef] {string}
+ *
+ * // XML Dsig
+ * @param options.key {Buffer}
+ * @param options.cert {Buffer}
+ * @param [options.signatureAlgorithm] {string}
+ * @param [options.digestAlgorithm] {string}
+ * @param [options.signatureNamespacePrefix] {string}
+ * @param [options.xpathToNodeBeforeSignature] {string}
+ *
+ * // XML encryption
+ * @param [options.encryptionCert] {Buffer}
+ * @param [options.encryptionPublicKey] {Buffer}
+ * @param [options.encryptionAlgorithm] {string}
+ * @param [options.keyEncryptionAlgorighm] {string}
+ *
+ * @param {Function} [callback] required if encrypting
+ * @return {*}
+ */
+exports.create = function createSignedAssertion(options, callback) {
+  return createAssertion(extractSaml20Options(options), {
+    signXml: SignXml.fromSignXmlOptions(options),
+    encryptXml: EncryptXml.fromEncryptXmlOptions(options)
+  }, callback);
+};
+
+/**
+ * Creates an **unsigned** SAML 2.0 assertion from the given options.
+ *
+ * @param options
+ *
+ * // SAML
+ * @param [options.uid] {string}
+ * @param [options.issuer] {string}
+ * @param [options.lifetimeInSeconds] {number}
+ * @param [options.audiences] {string|string[]}
+ * @param [options.recipient] {string}
+ * @param [options.inResponseTo] {string}
+ * @param [options.attributes]
+ * @param [options.includeAttributeNameFormat] {boolean}
+ * @param [options.typedAttributes] {boolean}
+ * @param [options.sessionIndex] {string}
+ * @param [options.nameIdentifier] {string}
+ * @param [options.nameIdentifierFormat] {string}
+ * @param [options.authnContextClassRef] {string}
+ *
+ * // XML encryption
+ * @param [options.encryptionCert] {Buffer}
+ * @param [options.encryptionPublicKey] {Buffer}
+ * @param [options.encryptionAlgorithm] {string}
+ * @param [options.keyEncryptionAlgorighm] {string}
+ *
+ * @param {Function} [callback] required if encrypting
+ * @return {*}
+ */
+exports.createUnsignedAssertion = function createUnsignedAssertion(options, callback) {
+  return createAssertion(extractSaml20Options(options), {
+    signXml: SignXml.unsigned,
+    encryptXml: EncryptXml.fromEncryptXmlOptions(options)
+  }, callback);
+};
+
+/**
+ * @param options SAML options
+ * @param strategies
+ * @param strategies.signXml {Function} strategy to sign the assertion
+ * @param strategies.encryptXml {Function} strategy to encrypt the assertion
+ * @param callback
+ * @return {*}
+ */
+function createAssertion(options, strategies, callback) {
   var doc = newSaml20Document();
 
   doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
@@ -112,7 +263,7 @@ exports.create = function(options, callback) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
   
   if (options.audiences) {
@@ -195,39 +346,10 @@ exports.create = function(options, callback) {
   var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    var opts = { 
-      location: { 
-        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
-        action: 'after'
-      },
-      prefix: options.signatureNamespacePrefix
-    };
-    
-    sig.computeSignature(token, opts);
-    signed = sig.getSignedXml();
+    signed = strategies.signXml(token);
   } catch(err){
     return utils.reportError(err, callback);
   }
 
-  if (!options.encryptionCert) {
-    if (callback) 
-      return callback(null, signed);
-    else 
-      return signed;
-  }
-
-
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
-    if (err) return callback(err);
-    encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-    callback(null, utils.removeWhitespace(encrypted));
-  });
-}; 
-
+  return strategies.encryptXml(signed, callback);
+}

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -125,6 +125,7 @@ var EncryptXml = Object.freeze({
  * @param [options.digestAlgorithm] {string}
  * @param [options.signatureNamespacePrefix] {string}
  * @param [options.xpathToNodeBeforeSignature] {string}
+ * @param [options.signatureIdAttribute] {String}
  *
  * // XML encryption
  * @param [options.encryptionCert] {Buffer}
@@ -137,7 +138,10 @@ var EncryptXml = Object.freeze({
  */
 exports.create = function createSignedAssertion(options, callback) {
   return createAssertion(extractSaml20Options(options), {
-    signXml: SignXml.fromSignXmlOptions(options),
+    signXml: SignXml.fromSignXmlOptions(Object.assign({
+      xpathToNodeBeforeSignature: "//*[local-name(.)='Issuer']",
+      signatureIdAttribute: 'ID'
+    }, options)),
     encryptXml: EncryptXml.fromEncryptXmlOptions(options)
   }, callback);
 };
@@ -284,10 +288,9 @@ function createAssertion(options, strategies, callback) {
     authnCtxClassRef.textContent = options.authnContextClassRef;
   }
 
-  var token = utils.removeWhitespace(doc.toString());
   var signed;
   try {
-    signed = strategies.signXml(token);
+    signed = strategies.signXml(doc);
   } catch(err){
     return utils.reportError(err, callback);
   }

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,11 +1,12 @@
 var fs = require('fs');
 var path = require('path');
+var async = require('async');
 var Parser = require('xmldom').DOMParser;
-var xmlenc = require('xml-encryption');
 var moment = require('moment');
 var xmlNameValidator = require('xml-name-validator');
 var is_uri = require('valid-url').is_uri;
 
+var EncryptXml = require('./xml/encrypt');
 var SignXml = require('./xml/sign');
 var utils = require('./utils');
 
@@ -68,37 +69,6 @@ function extractSaml20Options(opts) {
     authnContextClassRef: opts.authnContextClassRef
   };
 }
-
-var EncryptXml = Object.freeze({
-  fromEncryptXmlOptions: function (options) {
-    if (!options.encryptionCert) {
-      return this.unencrypted;
-    } else {
-      return this.encrypted({
-        rsa_pub: options.encryptionPublicKey,
-        pem: options.encryptionCert,
-        encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-        keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-      })
-    }
-  },
-  unencrypted: function(xml, callback) {
-    if (callback) {
-      return setImmediate(callback, null, xml);
-    } else {
-      return xml;
-    }
-  },
-  encrypted: function (encryptOptions) {
-    return function encrypt(xml, callback) {
-      xmlenc.encrypt(xml, encryptOptions, function(err, encrypted) {
-        if (err) return callback(err);
-        encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-        callback(null, utils.removeWhitespace(encrypted));
-      });
-    };
-  }
-});
 
 /**
  * Creates a signed SAML 2.0 assertion from the given options.
@@ -297,5 +267,17 @@ function createAssertion(options, strategies, callback) {
     return utils.reportError(err, callback);
   }
 
-  return strategies.encryptXml(signed, callback);
+  if (strategies.encryptXml === EncryptXml.unencrypted) {
+    return strategies.encryptXml(signed, callback);
+  }
+
+  async.waterfall([
+    function (cb) {
+      strategies.encryptXml(signed, cb)
+    },
+    function (encrypted, cb) {
+      var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+      cb(null, utils.removeWhitespace(assertion));
+    },
+  ], callback);
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,6 @@
+var fs = require('fs');
+var Parser = require('xmldom').DOMParser;
+
 exports.pemToCert = function(pem) {
   var cert = /-----BEGIN CERTIFICATE-----([^-]*)-----END CERTIFICATE-----/g.exec(pem.toString());
   if (cert && cert.length > 0) {
@@ -57,4 +60,19 @@ exports.removeWhitespace = function(xml) {
 
 function getRandomInt(min, max) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+/**
+ * Returns a function that can be called to create a new Node.
+ *
+ * @param {string} pathToTemplate an absolute path to a template file
+ * @return {function(): Node}
+ */
+exports.factoryForNode = function factoryForNode(pathToTemplate) {
+  var template = fs.readFileSync(pathToTemplate)
+  var prototypeDoc = new Parser().parseFromString(template.toString())
+
+  return function () {
+    return prototypeDoc.cloneNode(true);
+  };
 };

--- a/lib/xml/encrypt.js
+++ b/lib/xml/encrypt.js
@@ -6,12 +6,15 @@ exports.fromEncryptXmlOptions = function (options) {
   if (!options.encryptionCert) {
     return this.unencrypted;
   } else {
-    return this.encrypted({
+    var encryptOptions = {
       rsa_pub: options.encryptionPublicKey,
       pem: options.encryptionCert,
       encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-      keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-    });
+      keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+    };
+
+    // expose the encryptOptions as these are needed when adding the SubjectConfirmation
+    return Object.assign(this.encrypted(encryptOptions), { encryptOptions: encryptOptions });
   }
 };
 

--- a/lib/xml/encrypt.js
+++ b/lib/xml/encrypt.js
@@ -1,0 +1,33 @@
+var xmlenc = require('xml-encryption');
+
+var utils = require('../utils');
+
+exports.fromEncryptXmlOptions = function (options) {
+  if (!options.encryptionCert) {
+    return this.unencrypted;
+  } else {
+    return this.encrypted({
+      rsa_pub: options.encryptionPublicKey,
+      pem: options.encryptionCert,
+      encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+      keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+    });
+  }
+};
+
+exports.unencrypted = function (xml, callback) {
+  if (callback) {
+    return setImmediate(callback, null, xml);
+  } else {
+    return xml;
+  }
+};
+
+exports.encrypted = function (encryptOptions) {
+  return function encrypt(xml, callback) {
+    xmlenc.encrypt(xml, encryptOptions, function (err, encrypted) {
+      if (err) return callback(err);
+      callback(null, utils.removeWhitespace(encrypted));
+    });
+  };
+};

--- a/lib/xml/sign.js
+++ b/lib/xml/sign.js
@@ -1,0 +1,59 @@
+var utils = require('../utils');
+var SignedXml = require('xml-crypto').SignedXml;
+
+var algorithms = {
+  signature: {
+    'rsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+    'rsa-sha1':  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+  },
+  digest: {
+    'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
+    'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1'
+  }
+};
+
+exports.fromSignXmlOptions = function (options) {
+  if (!options.key)
+    throw new Error('Expect a private key in pem format');
+
+  if (!options.cert)
+    throw new Error('Expect a public key cert in pem format');
+
+  var key = options.key;
+  var pem = options.cert;
+  var signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
+  var digestAlgorithm = options.digestAlgorithm || 'sha256';
+  var signatureNamespacePrefix = (function (prefix) {
+    // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
+    return typeof prefix === 'string' ? prefix : '';
+  })(options.signatureNamespacePrefix || options.prefix);
+  var xpathToNodeBeforeSignature = options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']";
+
+  return function signXmlAssertion(token) {
+    var cert = utils.pemToCert(pem);
+
+    var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: 'ID' });
+    sig.addReference("//*[local-name(.)='Assertion']",
+      ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
+      algorithms.digest[digestAlgorithm]);
+
+    sig.signingKey = key;
+
+    sig.keyInfoProvider = {
+      getKeyInfo: function (key, prefix) {
+        prefix = prefix ? prefix + ':' : prefix;
+        return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
+      }
+    };
+
+    sig.computeSignature(token, {
+      location: { reference: xpathToNodeBeforeSignature, action: 'after' },
+      prefix: signatureNamespacePrefix
+    });
+    return sig.getSignedXml();
+  };
+};
+
+exports.unsigned = function (xml) {
+  return xml;
+}

--- a/lib/xml/sign.js
+++ b/lib/xml/sign.js
@@ -19,6 +19,9 @@ exports.fromSignXmlOptions = function (options) {
   if (!options.cert)
     throw new Error('Expect a public key cert in pem format');
 
+  if (!options.xpathToNodeBeforeSignature)
+    throw new Error('xpathToNodeBeforeSignature is required')
+
   var key = options.key;
   var pem = options.cert;
   var signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
@@ -27,12 +30,19 @@ exports.fromSignXmlOptions = function (options) {
     // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
     return typeof prefix === 'string' ? prefix : '';
   })(options.signatureNamespacePrefix || options.prefix);
-  var xpathToNodeBeforeSignature = options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']";
+  var xpathToNodeBeforeSignature = options.xpathToNodeBeforeSignature;
+  var idAttribute = options.signatureIdAttribute;
 
-  return function signXmlAssertion(token) {
+  /**
+   * @param {Document} doc
+   * @param {Function} [callback]
+   * @return {string}
+   */
+  return function signXmlDocument(doc, callback) {
+    var token = utils.removeWhitespace(doc.toString());
     var cert = utils.pemToCert(pem);
 
-    var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: 'ID' });
+    var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: idAttribute });
     sig.addReference("//*[local-name(.)='Assertion']",
       ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
       algorithms.digest[digestAlgorithm]);
@@ -50,10 +60,26 @@ exports.fromSignXmlOptions = function (options) {
       location: { reference: xpathToNodeBeforeSignature, action: 'after' },
       prefix: signatureNamespacePrefix
     });
-    return sig.getSignedXml();
+
+    var signed = sig.getSignedXml();
+    if (callback) {
+      setImmediate(callback, null, signed);
+    } else {
+      return signed;
+    }
   };
 };
 
-exports.unsigned = function (xml) {
-  return xml;
+/**
+ * @param {Document} doc
+ * @param {Function} [callback]
+ * @return {string}
+ */
+exports.unsigned = function (doc, callback) {
+  var xml = doc.toString();
+  if (callback) {
+    setImmediate(callback, null, xml)
+  } else {
+    return xml;
+  }
 }

--- a/lib/xml/sign.js
+++ b/lib/xml/sign.js
@@ -39,7 +39,7 @@ exports.fromSignXmlOptions = function (options) {
    * @return {string}
    */
   return function signXmlDocument(doc, callback) {
-    var token = utils.removeWhitespace(doc.toString());
+    var unsigned = exports.unsigned(doc);
     var cert = utils.pemToCert(pem);
 
     var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[signatureAlgorithm], idAttribute: idAttribute });
@@ -56,7 +56,7 @@ exports.fromSignXmlOptions = function (options) {
       }
     };
 
-    sig.computeSignature(token, {
+    sig.computeSignature(unsigned, {
       location: { reference: xpathToNodeBeforeSignature, action: 'after' },
       prefix: signatureNamespacePrefix
     });
@@ -76,7 +76,7 @@ exports.fromSignXmlOptions = function (options) {
  * @return {string}
  */
 exports.unsigned = function (doc, callback) {
-  var xml = doc.toString();
+  var xml = utils.removeWhitespace(doc.toString());
   if (callback) {
     setImmediate(callback, null, xml)
   } else {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "devDependencies": {
     "@commitlint/cli": "^9.1.2",
     "@commitlint/config-conventional": "^9.1.2",
+    "chai": "^4.2.0",
     "husky": "^4.3.0",
     "mocha": "3.5.3",
     "should": "~1.2.1",
@@ -19,7 +20,6 @@
   "license": "MIT",
   "dependencies": {
     "async": "~0.2.9",
-    "chai": "^4.2.0",
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "saml",
   "version": "0.14.0",
   "devDependencies": {
+    "@commitlint/cli": "^9.1.2",
+    "@commitlint/config-conventional": "^9.1.2",
+    "husky": "^4.3.0",
     "mocha": "3.5.3",
-    "should": "~1.2.1"
+    "should": "~1.2.1",
+    "standard-version": "^9.0.0"
   },
   "main": "./lib",
   "repository": "https://github.com/auth0/node-saml",
@@ -24,6 +28,12 @@
     "xpath": "0.0.5"
   },
   "scripts": {
+    "release": "standard-version",
     "test": "mocha"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "~0.2.9",
+    "chai": "^4.2.0",
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "~1.0.1",

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -1,403 +1,422 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    utils = require('./utils'),
-    moment = require('moment'),
-    should = require('should'),
-    xmldom = require('xmldom'),
-    xmlenc = require('xml-encryption'),
-    saml11 = require('../lib/saml11');
+var assert = require('chai').assert;
+var fs = require('fs');
+var moment = require('moment');
+var should = require('should');
+var xmldom = require('xmldom');
+var xmlenc = require('xml-encryption');
+
+var utils = require('./utils');
+var saml11 = require('../lib/saml11');
 
 describe('saml 1.1', function () {
 
-  it('should create a saml 1.1 signed assertion', function () {
-    // cert created with:
-    // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
-
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key')
-    };
-
-    var signedAssertion = saml11.create(options);
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+  saml11TestSuite({
+    createAssertion: 'create',
+    assertSignature: Object.assign(function (assertion, options) {
+      assert.isTrue(utils.isValidSignature(assertion, options.cert));
+    }, {
+      it: it
+    })
   });
 
-  it('should support specifying Issuer property', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      issuer: 'urn:issuer'
-    };
-
-    var signedAssertion = saml11.create(options);
-    assert.equal('urn:issuer', utils.getIssuer(signedAssertion));
+  saml11TestSuite({
+    createAssertion: 'createUnsignedAssertion',
+    assertSignature: Object.assign(function (assertion) {
+      assert.isEmpty(utils.getXmlSignatures(assertion));
+    }, {
+      it: it.skip
+    })
   });
+  
+  function saml11TestSuite(options) {
+    var createAssertion = options.createAssertion;
+    var assertSignature = options.assertSignature;
 
-  it('should create IssueInstant property', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key')
-    };
+    describe('#' + createAssertion, function () {
+      it('should create a saml 1.1 assertion', function () {
+        // cert created with:
+        // openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/CN=auth0.auth0.com/O=Auth0 LLC/C=US/ST=Washington/L=Redmond' -keyout auth0.key -out auth0.pem
 
-    var signedAssertion = saml11.create(options);
-    // 2012-12-17T01:59:14.782Z
-    var now = moment.utc();
-    var issueInstant = moment(utils.getIssueInstant(signedAssertion)).utc();
-    assert.equal(now.year(), issueInstant.year());
-    assert.equal(now.month(), issueInstant.month());
-    assert.equal(now.day(), issueInstant.day());
-    assert.equal(now.hours(), issueInstant.hours());
-    assert.equal(now.minutes(), issueInstant.minutes());
-  });
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key')
+        };
 
-  it('should create AssertionID and start with underscore', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key')
-    };
-
-    var signedAssertion = saml11.create(options);
-    var id = utils.getAssertionID(signedAssertion);
-    assert.equal('_', id[0]); // first char is underscore
-  });
-
-  it('should create NotBefore and NotOnOrAfter properties', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      lifetimeInSeconds: 600
-    };
-
-    var signedAssertion = saml11.create(options);
-    var conditions = utils.getConditions(signedAssertion);
-    assert.equal(1, conditions.length);
-    var notBefore = conditions[0].getAttribute('NotBefore');
-    var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
-    should.ok(notBefore);
-    should.ok(notOnOrAfter);
-
-    var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
-    assert.equal(600, lifetime);
-  });
-
-  it('should set audience restriction', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      audiences: 'urn:myapp'
-    };
-
-    var signedAssertion = saml11.create(options);
-    var audiences = utils.getAudiences(signedAssertion);
-    assert.equal(1, audiences.length);
-    assert.equal('urn:myapp', audiences[0].textContent);
-  });
-
-  it('should set multiple audience restriction', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      audiences: ['urn:myapp', 'urn:myapp2']
-    };
-
-    var signedAssertion = saml11.create(options);
-    var audiences = utils.getAudiences(signedAssertion);
-    assert.equal(2, audiences.length);
-    assert.equal('urn:myapp', audiences[0].textContent);
-    assert.equal('urn:myapp2', audiences[1].textContent);
-  });
-
-  it('should set attributes', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
-
-    var signedAssertion = saml11.create(options);
-
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(3, attributes.length);
-    assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
-    assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
-    assert.equal('name', attributes[1].getAttribute('AttributeName'));
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
-    assert.equal('Foo Bar', attributes[1].firstChild.textContent);
-    assert.equal('testaccent', attributes[2].getAttribute('AttributeName'));
-    assert.equal('http://example.org/claims', attributes[2].getAttribute('AttributeNamespace'));
-    assert.equal('fóo', attributes[2].firstChild.textContent);
-  });
-
-  it('should set attributes with multiple values', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role': ['admin','contributor']
-      }
-    };
-
-    var signedAssertion = saml11.create(options);
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(1, attributes.length);
-    assert.equal('role', attributes[0].getAttribute('AttributeName'));
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
-    assert.equal('admin', attributes[0].childNodes[0].textContent);
-    assert.equal('contributor', attributes[0].childNodes[1].textContent);
-  });
-
-  it('should set NameIdentifier', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-
-    var signedAssertion = saml11.create(options);
-    var nameIdentifier = utils.getNameIdentifier(signedAssertion);
-    assert.equal('foo', nameIdentifier.textContent);
-  });
-
-  it('should not contains line breaks', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-
-    var signedAssertion = saml11.create(options);
-    assert.equal(-1, signedAssertion.indexOf('\n'));
-  });
-
-  it('should set AuthenticationInstant', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-
-    var signedAssertion = saml11.create(options);
-    var authenticationStatement = utils.getAuthenticationStatement(signedAssertion);
-    assert.ok(!!authenticationStatement.getAttribute('AuthenticationInstant'));
-  });
-
-  it('should set AuthenticationStatement NameIdentifier', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-    var signedAssertion = saml11.create(options);
-    var nameIdentifier = utils.getAuthenticationStatement(signedAssertion)
-                              .getElementsByTagName('saml:NameIdentifier')[0]
-                              .textContent;
-    assert.equal('foo', nameIdentifier);
-  });
-
-  it('should set AuthenticationStatement NameFormat', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-    var signedAssertion = saml11.create(options);
-    var format = utils.getAuthenticationStatement(signedAssertion)
-                              .getElementsByTagName('saml:NameIdentifier')[0]
-                              .getAttribute('Format');
-    assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', format);
-  });
-
-  it('should set AttirubteStatement NameFormat', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo'
-    };
-    var signedAssertion = saml11.create(options);
-    var format = utils.getNameIdentifier(signedAssertion)
-                              .getAttribute('Format');
-    assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', format);
-  });
-
-  it('should override AttirubteStatement NameFormat', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      nameIdentifier: 'foo',
-      nameIdentifierFormat: 'http://foo'
-    };
-    var signedAssertion = saml11.create(options);
-    var format = utils.getAuthenticationStatement(signedAssertion)
-                          .getElementsByTagName('saml:NameIdentifier')[0]
-                          .getAttribute('Format');
-
-    assert.equal('http://foo', format);
-  });
-
-  it('should place signature where specified', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']"
-    };
-    var signedAssertion = saml11.create(options);
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    
-    var signature = doc.documentElement.getElementsByTagName('Signature');
-
-    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
-  });
-
-  it('should test the whole thing', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      issuer: 'urn:issuer',
-      lifetimeInSeconds: 600,
-      audiences: 'urn:myapp',
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
-      },
-      nameIdentifier:       'foo',
-      nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
-    };
-
-    var signedAssertion = saml11.create(options);
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-
-    var nameIdentifier = utils.getNameIdentifier(signedAssertion);
-    assert.equal('foo', nameIdentifier.textContent);
-    assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
-
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(2, attributes.length);
-    assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
-    assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
-    assert.equal('name', attributes[1].getAttribute('AttributeName'));
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
-    assert.equal('Foo Bar', attributes[1].firstChild.textContent);
-
-    assert.equal('urn:issuer', utils.getIssuer(signedAssertion));
-
-    var conditions = utils.getConditions(signedAssertion);
-    assert.equal(1, conditions.length);
-    var notBefore = conditions[0].getAttribute('NotBefore');
-    var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
-    should.ok(notBefore);
-    should.ok(notOnOrAfter);
-
-    var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
-    assert.equal(600, lifetime);
-
-  });
-
-  describe('encryption', function () {
-
-    it('should create a saml 1.1 signed and encrypted assertion', function (done) {
-      var options = {
-        cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem')
-      };
-
-      saml11.create(options, function(err, encrypted) {
-        if (err) return done(err);
-        
-        xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-          if (err) return done(err);
-          var isValid = utils.isValidSignature(decrypted, options.cert);
-          assert.equal(true, isValid);
-          done();
-        });
+        var signedAssertion = saml11[createAssertion](options);
+        assertSignature(signedAssertion, options);
       });
-    });
 
-    it('should support holder-of-key suject confirmationmethod', function (done) {
-      var options = {
-        cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        subjectConfirmationMethod: 'holder-of-key'
-      };
+      it('should support specifying Issuer property', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          issuer: 'urn:issuer'
+        };
 
-      saml11.create(options, function(err, encrypted, proofSecret) {
-        if (err) return done(err);
-        
-        xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-          if (err) return done(err);
-          
-          var doc = new xmldom.DOMParser().parseFromString(decrypted);
-          var subjectConfirmationNodes = doc.documentElement.getElementsByTagName('saml:SubjectConfirmation');
-          assert.equal(2, subjectConfirmationNodes.length);
-          for (var i=0;i<subjectConfirmationNodes.length;i++) {
-            var method = subjectConfirmationNodes[i].getElementsByTagName('saml:ConfirmationMethod')[0];
-            assert.equal(method.textContent, 'urn:oasis:names:tc:SAML:1.0:cm:holder-of-key');
+        var signedAssertion = saml11[createAssertion](options);
+        assert.equal('urn:issuer', utils.getIssuer(signedAssertion));
+      });
 
-            var decryptedProofSecret = xmlenc.decryptKeyInfo(subjectConfirmationNodes[i], options);
-            assert.equal(proofSecret.toString('base64'), decryptedProofSecret.toString('base64'));
+      it('should create IssueInstant property', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key')
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        // 2012-12-17T01:59:14.782Z
+        var now = moment.utc();
+        var issueInstant = moment(utils.getIssueInstant(signedAssertion)).utc();
+        assert.equal(now.year(), issueInstant.year());
+        assert.equal(now.month(), issueInstant.month());
+        assert.equal(now.day(), issueInstant.day());
+        assert.equal(now.hours(), issueInstant.hours());
+        assert.equal(now.minutes(), issueInstant.minutes());
+      });
+
+      it('should create AssertionID and start with underscore', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key')
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var id = utils.getAssertionID(signedAssertion);
+        assert.equal('_', id[0]); // first char is underscore
+      });
+
+      it('should create NotBefore and NotOnOrAfter properties', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          lifetimeInSeconds: 600
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var conditions = utils.getConditions(signedAssertion);
+        assert.equal(1, conditions.length);
+        var notBefore = conditions[0].getAttribute('NotBefore');
+        var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
+        should.ok(notBefore);
+        should.ok(notOnOrAfter);
+
+        var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
+        assert.equal(600, lifetime);
+      });
+
+      it('should set audience restriction', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          audiences: 'urn:myapp'
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var audiences = utils.getAudiences(signedAssertion);
+        assert.equal(1, audiences.length);
+        assert.equal('urn:myapp', audiences[0].textContent);
+      });
+
+      it('should set multiple audience restriction', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          audiences: ['urn:myapp', 'urn:myapp2']
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var audiences = utils.getAudiences(signedAssertion);
+        assert.equal(2, audiences.length);
+        assert.equal('urn:myapp', audiences[0].textContent);
+        assert.equal('urn:myapp2', audiences[1].textContent);
+      });
+
+      it('should set attributes', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
           }
+        };
 
-          done();
+        var signedAssertion = saml11[createAssertion](options);
+
+        assertSignature(signedAssertion, options);
+
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(3, attributes.length);
+        assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
+        assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
+        assert.equal('name', attributes[1].getAttribute('AttributeName'));
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
+        assert.equal('Foo Bar', attributes[1].firstChild.textContent);
+        assert.equal('testaccent', attributes[2].getAttribute('AttributeName'));
+        assert.equal('http://example.org/claims', attributes[2].getAttribute('AttributeNamespace'));
+        assert.equal('fóo', attributes[2].firstChild.textContent);
+      });
+
+      it('should set attributes with multiple values', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/role': ['admin','contributor']
+          }
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(1, attributes.length);
+        assert.equal('role', attributes[0].getAttribute('AttributeName'));
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
+        assert.equal('admin', attributes[0].childNodes[0].textContent);
+        assert.equal('contributor', attributes[0].childNodes[1].textContent);
+      });
+
+      it('should set NameIdentifier', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var nameIdentifier = utils.getNameIdentifier(signedAssertion);
+        assert.equal('foo', nameIdentifier.textContent);
+      });
+
+      it('should not contains line breaks', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        assert.equal(-1, signedAssertion.indexOf('\n'));
+      });
+
+      it('should set AuthenticationInstant', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        var authenticationStatement = utils.getAuthenticationStatement(signedAssertion);
+        assert.ok(!!authenticationStatement.getAttribute('AuthenticationInstant'));
+      });
+
+      it('should set AuthenticationStatement NameIdentifier', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+        var signedAssertion = saml11[createAssertion](options);
+        var nameIdentifier = utils.getAuthenticationStatement(signedAssertion)
+        .getElementsByTagName('saml:NameIdentifier')[0]
+          .textContent;
+        assert.equal('foo', nameIdentifier);
+      });
+
+      it('should set AuthenticationStatement NameFormat', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+        var signedAssertion = saml11[createAssertion](options);
+        var format = utils.getAuthenticationStatement(signedAssertion)
+        .getElementsByTagName('saml:NameIdentifier')[0]
+        .getAttribute('Format');
+        assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', format);
+      });
+
+      it('should set AttirubteStatement NameFormat', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo'
+        };
+        var signedAssertion = saml11[createAssertion](options);
+        var format = utils.getNameIdentifier(signedAssertion)
+        .getAttribute('Format');
+        assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', format);
+      });
+
+      it('should override AttirubteStatement NameFormat', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          nameIdentifier: 'foo',
+          nameIdentifierFormat: 'http://foo'
+        };
+        var signedAssertion = saml11[createAssertion](options);
+        var format = utils.getAuthenticationStatement(signedAssertion)
+        .getElementsByTagName('saml:NameIdentifier')[0]
+        .getAttribute('Format');
+
+        assert.equal('http://foo', format);
+      });
+
+      assertSignature.it('should place signature where specified', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']"
+        };
+        var signedAssertion = saml11[createAssertion](options);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+
+        var signature = doc.documentElement.getElementsByTagName('Signature');
+
+        assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+      });
+
+      it('should test the whole thing', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          issuer: 'urn:issuer',
+          lifetimeInSeconds: 600,
+          audiences: 'urn:myapp',
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
+          },
+          nameIdentifier:       'foo',
+          nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+        };
+
+        var signedAssertion = saml11[createAssertion](options);
+        assertSignature(signedAssertion, options);
+
+        var nameIdentifier = utils.getNameIdentifier(signedAssertion);
+        assert.equal('foo', nameIdentifier.textContent);
+        assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
+
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(2, attributes.length);
+        assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
+        assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
+        assert.equal('name', attributes[1].getAttribute('AttributeName'));
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
+        assert.equal('Foo Bar', attributes[1].firstChild.textContent);
+
+        assert.equal('urn:issuer', utils.getIssuer(signedAssertion));
+
+        var conditions = utils.getConditions(signedAssertion);
+        assert.equal(1, conditions.length);
+        var notBefore = conditions[0].getAttribute('NotBefore');
+        var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
+        should.ok(notBefore);
+        should.ok(notOnOrAfter);
+
+        var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
+        assert.equal(600, lifetime);
+
+      });
+
+      describe('encryption', function () {
+
+        it('should create a saml 1.1 encrypted assertion', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem')
+          };
+
+          saml11[createAssertion](options, function(err, encrypted) {
+            if (err) return done(err);
+
+            xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
+              if (err) return done(err);
+              assertSignature(decrypted, options);
+              done();
+            });
+          });
+        });
+
+        it('should support holder-of-key suject confirmationmethod', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            subjectConfirmationMethod: 'holder-of-key'
+          };
+
+          saml11[createAssertion](options, function(err, encrypted, proofSecret) {
+            if (err) return done(err);
+
+            xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
+              if (err) return done(err);
+
+              var doc = new xmldom.DOMParser().parseFromString(decrypted);
+              var subjectConfirmationNodes = doc.documentElement.getElementsByTagName('saml:SubjectConfirmation');
+              assert.equal(2, subjectConfirmationNodes.length);
+              for (var i=0;i<subjectConfirmationNodes.length;i++) {
+                var method = subjectConfirmationNodes[i].getElementsByTagName('saml:ConfirmationMethod')[0];
+                assert.equal(method.textContent, 'urn:oasis:names:tc:SAML:1.0:cm:holder-of-key');
+
+                var decryptedProofSecret = xmlenc.decryptKeyInfo(subjectConfirmationNodes[i], options);
+                assert.equal(proofSecret.toString('base64'), decryptedProofSecret.toString('base64'));
+              }
+
+              done();
+            });
+          });
+        });
+
+        it('should set attributes', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            attributes: {
+              'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+              'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+              'http://example.org/claims/testaccent': 'fóo', // should supports accents
+              'http://undefinedattribute/ws/com.com': undefined
+            }
+          };
+
+          saml11[createAssertion](options, function(err, encrypted) {
+            if (err) return done(err);
+
+            xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
+              if (err) return done(err);
+
+              assertSignature(decrypted, options);
+
+              var attributes = utils.getAttributes(decrypted);
+              assert.equal(3, attributes.length);
+              assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
+              assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
+              assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
+              assert.equal('name', attributes[1].getAttribute('AttributeName'));
+              assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
+              assert.equal('Foo Bar', attributes[1].firstChild.textContent);
+              assert.equal('testaccent', attributes[2].getAttribute('AttributeName'));
+              assert.equal('http://example.org/claims', attributes[2].getAttribute('AttributeNamespace'));
+              assert.equal('fóo', attributes[2].firstChild.textContent);
+
+              done();
+            });
+          });
         });
       });
     });
-
-    it('should set attributes', function (done) {
-      var options = {
-        cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        attributes: {
-          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-          'http://example.org/claims/testaccent': 'fóo', // should supports accents
-          'http://undefinedattribute/ws/com.com': undefined
-        }
-      };
-
-      saml11.create(options, function(err, encrypted) {
-        if (err) return done(err);
-        
-        xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-          if (err) return done(err);
-
-          var isValid = utils.isValidSignature(decrypted, options.cert);
-          assert.equal(true, isValid);
-          
-          var attributes = utils.getAttributes(decrypted);
-          assert.equal(3, attributes.length);
-          assert.equal('emailaddress', attributes[0].getAttribute('AttributeName'));
-          assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[0].getAttribute('AttributeNamespace'));
-          assert.equal('foo@bar.com', attributes[0].firstChild.textContent);
-          assert.equal('name', attributes[1].getAttribute('AttributeName'));
-          assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims', attributes[1].getAttribute('AttributeNamespace'));
-          assert.equal('Foo Bar', attributes[1].firstChild.textContent);
-          assert.equal('testaccent', attributes[2].getAttribute('AttributeName'));
-          assert.equal('http://example.org/claims', attributes[2].getAttribute('AttributeNamespace'));
-          assert.equal('fóo', attributes[2].firstChild.textContent);
-          
-          done();
-        });
-      });
-    });
-
-  });
-
+  }
 });

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -1,552 +1,553 @@
-var assert = require('assert'),
-    fs = require('fs'),
-    utils = require('./utils'),
-    moment = require('moment'),
-    should = require('should'),
-    xmldom = require('xmldom'),
-    xmlenc = require('xml-encryption'),
-    saml = require('../lib/saml20');
+var assert = require('chai').assert;
+var fs = require('fs');
+var utils = require('./utils');
+var moment = require('moment');
+var should = require('should');
+var xmldom = require('xmldom');
+var xmlenc = require('xml-encryption');
+
+var saml = require('../lib/saml20');
 
 describe('saml 2.0', function () {
-
-  it('whole thing with default authnContextClassRef', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      issuer: 'urn:issuer',
-      lifetimeInSeconds: 600,
-      audiences: 'urn:myapp',
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
-      },
-      nameIdentifier:       'foo',
-      nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
-    };
-
-    var signedAssertion = saml.create(options);
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-
-    
-    var nameIdentifier = utils.getNameID(signedAssertion);
-    assert.equal('foo', nameIdentifier.textContent);
-    assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
-
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(2, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('Foo Bar', attributes[1].textContent);
-
-    assert.equal('urn:issuer', utils.getSaml2Issuer(signedAssertion).textContent);
-
-    var conditions = utils.getConditions(signedAssertion);
-    assert.equal(1, conditions.length);
-    var notBefore = conditions[0].getAttribute('NotBefore');
-    var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
-    should.ok(notBefore);
-    should.ok(notOnOrAfter);
-
-    var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
-    assert.equal(600, lifetime);
-
-    var authnContextClassRef = utils.getAuthnContextClassRef(signedAssertion);
-    assert.equal('urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified', authnContextClassRef.textContent);
+  saml20TestSuite({
+    createAssertion: 'create',
+    assertSignature: Object.assign(function (assertion, options) {
+        assert.isTrue(utils.isValidSignature(assertion, options.cert));
+    }, {
+      it: it
+    })
   });
 
-  it('should set attributes', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
-
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(3, attributes.length);
-    assert.equal('saml:AttributeStatement', attributes[0].parentNode.nodeName);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
-    assert.equal('fóo', attributes[2].textContent);
+  saml20TestSuite({
+    createAssertion: 'createUnsignedAssertion',
+    assertSignature: Object.assign(function (assertion) {
+        assert.isEmpty(utils.getXmlSignatures(assertion));
+    }, {
+      it: it.skip
+    })
   });
 
-  it('should set attributes with the correct attribute type', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://attributes/boolean': true, 
-        'http://attributes/booleanNegative': false, 
-        'http://attributes/number': 123, 
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+  function saml20TestSuite({ createAssertion, assertSignature }) {
+    describe('#' + createAssertion, function () {
+      it('whole thing with default authnContextClassRef', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          issuer: 'urn:issuer',
+          lifetimeInSeconds: 600,
+          audiences: 'urn:myapp',
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
+          },
+          nameIdentifier: 'foo',
+          nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified'
+        };
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        var signedAssertion = saml[createAssertion](options);
+        assertSignature(signedAssertion, options);
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(6, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
-    assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
-    assert.equal('fóo', attributes[2].textContent);
-    assert.equal('http://attributes/boolean', attributes[3].getAttribute('Name'));
-    assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
-    assert.equal('true', attributes[3].textContent);
-    assert.equal('http://attributes/booleanNegative', attributes[4].getAttribute('Name'));
-    assert.equal('xs:boolean', attributes[4].firstChild.getAttribute('xsi:type'));
-    assert.equal('false', attributes[4].textContent);
-    assert.equal('http://attributes/number', attributes[5].getAttribute('Name'));
-    assert.equal('xs:double', attributes[5].firstChild.getAttribute('xsi:type'));
-    assert.equal('123', attributes[5].textContent);
-  });
+        var nameIdentifier = utils.getNameID(signedAssertion);
+        assert.equal('foo', nameIdentifier.textContent);
+        assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
 
-  it('should set attributes with the correct attribute type and NameFormat', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'testaccent': 'fóo', // should supports accents
-        'urn:test:1:2:3': true,
-        '123~oo': 123, 
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(2, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('Foo Bar', attributes[1].textContent);
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        assert.equal('urn:issuer', utils.getSaml2Issuer(signedAssertion).textContent);
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(5, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[0].getAttribute('NameFormat'));    
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[1].getAttribute('NameFormat'));    
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('testaccent', attributes[2].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:basic', attributes[2].getAttribute('NameFormat'));    
-    assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
-    assert.equal('fóo', attributes[2].textContent);
-    assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[3].getAttribute('NameFormat'));
-    assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
-    assert.equal('true', attributes[3].textContent);
-    assert.equal('123~oo', attributes[4].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', attributes[4].getAttribute('NameFormat'));    
-    assert.equal('xs:double', attributes[4].firstChild.getAttribute('xsi:type'));
-    assert.equal('123', attributes[4].textContent);
-  });
+        var conditions = utils.getConditions(signedAssertion);
+        assert.equal(1, conditions.length);
+        var notBefore = conditions[0].getAttribute('NotBefore');
+        var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
+        should.ok(notBefore);
+        should.ok(notOnOrAfter);
 
-  it('should set attributes to anytpe when typedAttributes is false', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      typedAttributes: false,
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://attributes/boolean': true, 
-        'http://attributes/number': 123, 
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
+        assert.equal(600, lifetime);
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        var authnContextClassRef = utils.getAuthnContextClassRef(signedAssertion);
+        assert.equal('urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified', authnContextClassRef.textContent);
+      });
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(5, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
-    assert.equal('xs:anyType', attributes[2].firstChild.getAttribute('xsi:type'));
-    assert.equal('fóo', attributes[2].textContent);
-    assert.equal('http://attributes/boolean', attributes[3].getAttribute('Name'));
-    assert.equal('xs:anyType', attributes[3].firstChild.getAttribute('xsi:type'));
-    assert.equal('true', attributes[3].textContent);
-    assert.equal('http://attributes/number', attributes[4].getAttribute('Name'));
-    assert.equal('xs:anyType', attributes[4].firstChild.getAttribute('xsi:type'));
-    assert.equal('123', attributes[4].textContent);
-  });
+      it('should set attributes', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-  it('should not set NameFormat in attributes when includeAttributeNameFormat is false', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      typedAttributes: false,
-      includeAttributeNameFormat: false,
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'testaccent': 'fóo', // should supports accents
-        'urn:test:1:2:3': true,
-        '123~oo': 123, 
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var signedAssertion = saml[createAssertion](options);
+        assertSignature(signedAssertion, options);
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(3, attributes.length);
+        assert.equal('saml:AttributeStatement', attributes[0].parentNode.nodeName);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
+        assert.equal('fóo', attributes[2].textContent);
+      });
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(5, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('', attributes[0].getAttribute('NameFormat'));    
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('', attributes[1].getAttribute('NameFormat'));    
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('testaccent', attributes[2].getAttribute('Name'));
-    assert.equal('', attributes[2].getAttribute('NameFormat'));    
-    assert.equal('fóo', attributes[2].textContent);
-    assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
-    assert.equal('', attributes[3].getAttribute('NameFormat'));
-    assert.equal('true', attributes[3].textContent);
-    assert.equal('123~oo', attributes[4].getAttribute('Name'));
-    assert.equal('', attributes[4].getAttribute('NameFormat'));    
-    assert.equal('123', attributes[4].textContent);
-  });
+      it('should set attributes with the correct attribute type', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://attributes/boolean': true,
+            'http://attributes/booleanNegative': false,
+            'http://attributes/number': 123,
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-  it('should ignore undefined attributes in array', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'arrayAttribute': [ 'foo', undefined, 'bar'],
-        'urn:test:1:2:3': true,
-        '123~oo': 123, 
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var signedAssertion = saml[createAssertion](options);
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        assertSignature(signedAssertion, options);
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(5, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[0].getAttribute('NameFormat'));    
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[1].getAttribute('NameFormat'));    
-    assert.equal('Foo Bar', attributes[1].textContent);
-    assert.equal('arrayAttribute', attributes[2].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:basic', attributes[2].getAttribute('NameFormat'));    
-    assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
-    assert.equal(2, attributes[2].childNodes.length);
-    assert.equal('foo', attributes[2].childNodes[0].textContent);
-    // undefined should not be here
-    assert.equal('bar', attributes[2].childNodes[1].textContent);
-    assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[3].getAttribute('NameFormat'));
-    assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
-    assert.equal('true', attributes[3].textContent);
-    assert.equal('123~oo', attributes[4].getAttribute('Name'));
-    assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', attributes[4].getAttribute('NameFormat'));    
-    assert.equal('xs:double', attributes[4].firstChild.getAttribute('xsi:type'));
-    assert.equal('123', attributes[4].textContent);
-  });
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(6, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
+        assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
+        assert.equal('fóo', attributes[2].textContent);
+        assert.equal('http://attributes/boolean', attributes[3].getAttribute('Name'));
+        assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
+        assert.equal('true', attributes[3].textContent);
+        assert.equal('http://attributes/booleanNegative', attributes[4].getAttribute('Name'));
+        assert.equal('xs:boolean', attributes[4].firstChild.getAttribute('xsi:type'));
+        assert.equal('false', attributes[4].textContent);
+        assert.equal('http://attributes/number', attributes[5].getAttribute('Name'));
+        assert.equal('xs:double', attributes[5].firstChild.getAttribute('xsi:type'));
+        assert.equal('123', attributes[5].textContent);
+      });
 
-  it('whole thing with specific authnContextClassRef', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      issuer: 'urn:issuer',
-      lifetimeInSeconds: 600,
-      audiences: 'urn:myapp',
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
-      },
-      nameIdentifier:       'foo',
-      nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
-      authnContextClassRef: 'specific'
-    };
+      it('should set attributes with the correct attribute type and NameFormat', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'testaccent': 'fóo', // should supports accents
+            'urn:test:1:2:3': true,
+            '123~oo': 123,
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-    var signedAssertion = saml.create(options);
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+        var signedAssertion = saml[createAssertion](options);
 
-    
-    var nameIdentifier = utils.getNameID(signedAssertion);
-    assert.equal('foo', nameIdentifier.textContent);
-    assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
+        assertSignature(signedAssertion, options);
 
-    var attributes = utils.getAttributes(signedAssertion);
-    assert.equal(2, attributes.length);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-    assert.equal('foo@bar.com', attributes[0].textContent);
-    assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-    assert.equal('Foo Bar', attributes[1].textContent);
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(5, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[0].getAttribute('NameFormat'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[1].getAttribute('NameFormat'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('testaccent', attributes[2].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:basic', attributes[2].getAttribute('NameFormat'));
+        assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
+        assert.equal('fóo', attributes[2].textContent);
+        assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[3].getAttribute('NameFormat'));
+        assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
+        assert.equal('true', attributes[3].textContent);
+        assert.equal('123~oo', attributes[4].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', attributes[4].getAttribute('NameFormat'));
+        assert.equal('xs:double', attributes[4].firstChild.getAttribute('xsi:type'));
+        assert.equal('123', attributes[4].textContent);
+      });
 
-    assert.equal('urn:issuer', utils.getSaml2Issuer(signedAssertion).textContent);
+      it('should set attributes to anytpe when typedAttributes is false', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          typedAttributes: false,
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://attributes/boolean': true,
+            'http://attributes/number': 123,
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-    var conditions = utils.getConditions(signedAssertion);
-    assert.equal(1, conditions.length);
-    var notBefore = conditions[0].getAttribute('NotBefore');
-    var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
-    should.ok(notBefore);
-    should.ok(notOnOrAfter);
+        var signedAssertion = saml[createAssertion](options);
 
-    var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
-    assert.equal(600, lifetime);
+        assertSignature(signedAssertion, options);
 
-    var authnContextClassRef = utils.getAuthnContextClassRef(signedAssertion);
-    assert.equal('specific', authnContextClassRef.textContent);
-  });
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(5, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
+        assert.equal('xs:anyType', attributes[2].firstChild.getAttribute('xsi:type'));
+        assert.equal('fóo', attributes[2].textContent);
+        assert.equal('http://attributes/boolean', attributes[3].getAttribute('Name'));
+        assert.equal('xs:anyType', attributes[3].firstChild.getAttribute('xsi:type'));
+        assert.equal('true', attributes[3].textContent);
+        assert.equal('http://attributes/number', attributes[4].getAttribute('Name'));
+        assert.equal('xs:anyType', attributes[4].firstChild.getAttribute('xsi:type'));
+        assert.equal('123', attributes[4].textContent);
+      });
 
-  it('should place signature where specified', function () {
-     var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+      it('should not set NameFormat in attributes when includeAttributeNameFormat is false', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          typedAttributes: false,
+          includeAttributeNameFormat: false,
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'testaccent': 'fóo', // should supports accents
+            'urn:test:1:2:3': true,
+            '123~oo': 123,
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var signature = doc.documentElement.getElementsByTagName('Signature');
+        var signedAssertion = saml[createAssertion](options);
 
-    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
-  });
+        assertSignature(signedAssertion, options);
 
-  it('should place signature with prefix where specified', function () {
-     var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      signatureNamespacePrefix: 'anyprefix',
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(5, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('', attributes[0].getAttribute('NameFormat'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('', attributes[1].getAttribute('NameFormat'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('testaccent', attributes[2].getAttribute('Name'));
+        assert.equal('', attributes[2].getAttribute('NameFormat'));
+        assert.equal('fóo', attributes[2].textContent);
+        assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
+        assert.equal('', attributes[3].getAttribute('NameFormat'));
+        assert.equal('true', attributes[3].textContent);
+        assert.equal('123~oo', attributes[4].getAttribute('Name'));
+        assert.equal('', attributes[4].getAttribute('NameFormat'));
+        assert.equal('123', attributes[4].textContent);
+      });
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var signature = doc.documentElement.getElementsByTagName(options.signatureNamespacePrefix + ':Signature');
-    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
-  });
+      it('should ignore undefined attributes in array', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'arrayAttribute': [ 'foo', undefined, 'bar'],
+            'urn:test:1:2:3': true,
+            '123~oo': 123,
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-  it('should place signature with prefix where specified (backwards compat)', function () {
-     var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      prefix: 'anyprefix',
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var signedAssertion = saml[createAssertion](options);
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var signature = doc.documentElement.getElementsByTagName(options.signatureNamespacePrefix + ':Signature');
-    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
-  });
+        assertSignature(signedAssertion, options);
 
-  it('should ignore prefix if not a string', function () {
-     var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      signatureNamespacePrefix: 123,
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(5, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[0].getAttribute('NameFormat'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[1].getAttribute('NameFormat'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+        assert.equal('arrayAttribute', attributes[2].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:basic', attributes[2].getAttribute('NameFormat'));
+        assert.equal('xs:string', attributes[2].firstChild.getAttribute('xsi:type'));
+        assert.equal(2, attributes[2].childNodes.length);
+        assert.equal('foo', attributes[2].childNodes[0].textContent);
+        // undefined should not be here
+        assert.equal('bar', attributes[2].childNodes[1].textContent);
+        assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:uri', attributes[3].getAttribute('NameFormat'));
+        assert.equal('xs:boolean', attributes[3].firstChild.getAttribute('xsi:type'));
+        assert.equal('true', attributes[3].textContent);
+        assert.equal('123~oo', attributes[4].getAttribute('Name'));
+        assert.equal('urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified', attributes[4].getAttribute('NameFormat'));
+        assert.equal('xs:double', attributes[4].firstChild.getAttribute('xsi:type'));
+        assert.equal('123', attributes[4].textContent);
+      });
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var signature = doc.documentElement.getElementsByTagName('Signature');
-    assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
-  });
+      it('whole thing with specific authnContextClassRef', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          issuer: 'urn:issuer',
+          lifetimeInSeconds: 600,
+          audiences: 'urn:myapp',
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar'
+          },
+          nameIdentifier:       'foo',
+          nameIdentifierFormat: 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
+          authnContextClassRef: 'specific'
+        };
+
+        var signedAssertion = saml[createAssertion](options);
+        assertSignature(signedAssertion, options);
+
+        var nameIdentifier = utils.getNameID(signedAssertion);
+        assert.equal('foo', nameIdentifier.textContent);
+        assert.equal('urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified', nameIdentifier.getAttribute('Format'));
+
+        var attributes = utils.getAttributes(signedAssertion);
+        assert.equal(2, attributes.length);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+        assert.equal('foo@bar.com', attributes[0].textContent);
+        assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+        assert.equal('Foo Bar', attributes[1].textContent);
+
+        assert.equal('urn:issuer', utils.getSaml2Issuer(signedAssertion).textContent);
+
+        var conditions = utils.getConditions(signedAssertion);
+        assert.equal(1, conditions.length);
+        var notBefore = conditions[0].getAttribute('NotBefore');
+        var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
+        should.ok(notBefore);
+        should.ok(notOnOrAfter);
+
+        var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
+        assert.equal(600, lifetime);
+
+        var authnContextClassRef = utils.getAuthnContextClassRef(signedAssertion);
+        assert.equal('specific', authnContextClassRef.textContent);
+      });
+
+      assertSignature.it('should place signature where specified', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
+
+        var signedAssertion = saml[createAssertion](options);
+
+        assertSignature(signedAssertion, options);
+
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var signature = doc.documentElement.getElementsByTagName('Signature');
+
+        assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+      });
+
+      assertSignature.it('should place signature with prefix where specified', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          signatureNamespacePrefix: 'anyprefix',
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
+
+        var signedAssertion = saml[createAssertion](options);
+
+        assertSignature(signedAssertion, options);
+
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var signature = doc.documentElement.getElementsByTagName(options.signatureNamespacePrefix + ':Signature');
+        assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+      });
+
+      assertSignature.it('should place signature with prefix where specified (backwards compat)', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          prefix: 'anyprefix',
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
+
+        var signedAssertion = saml[createAssertion](options);
+
+        assertSignature(signedAssertion, options);
+
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var signature = doc.documentElement.getElementsByTagName(options.prefix + ':Signature');
+        assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+      });
+
+      assertSignature.it('should ignore prefix if not a string', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          signatureNamespacePrefix: 123,
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
+
+        var signedAssertion = saml[createAssertion](options);
+
+        assertSignature(signedAssertion, options);
+
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var signature = doc.documentElement.getElementsByTagName('Signature');
+        assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
+      });
 
 
-  it('should not include AudienceRestriction when there are no audiences', function () {
-     var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      signatureNamespacePrefix: 123,
-      attributes: {
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-        'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-        'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
-        'http://example.org/claims/testaccent': 'fóo', // should supports accents
-        'http://undefinedattribute/ws/com.com': undefined
-      }
-    };
+      it('should not include AudienceRestriction when there are no audiences', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          signatureNamespacePrefix: 123,
+          attributes: {
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+            'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+            'http://example.org/claims/testemptyarray': [], // should dont include empty arrays
+            'http://example.org/claims/testaccent': 'fóo', // should supports accents
+            'http://undefinedattribute/ws/com.com': undefined
+          }
+        };
 
-    var signedAssertion = saml.create(options);
-    
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
-    
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var audienceRestriction = doc.documentElement.getElementsByTagName('saml:AudienceRestriction');
-    assert.equal(audienceRestriction.length, 0);
-  });
+        var signedAssertion = saml[createAssertion](options);
 
-  it('should not include AttributeStatement when there are no attributes', function () {
-    var options = {
-      cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-      key: fs.readFileSync(__dirname + '/test-auth0.key'),
-      xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
-      signatureNamespacePrefix: 123
-    };
+        assertSignature(signedAssertion, options);
 
-    var signedAssertion = saml.create(options);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var audienceRestriction = doc.documentElement.getElementsByTagName('saml:AudienceRestriction');
+        assert.equal(audienceRestriction.length, 0);
+      });
 
-    var isValid = utils.isValidSignature(signedAssertion, options.cert);
-    assert.equal(true, isValid);
+      it('should not include AttributeStatement when there are no attributes', function () {
+        var options = {
+          cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+          key: fs.readFileSync(__dirname + '/test-auth0.key'),
+          xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']",
+          signatureNamespacePrefix: 123
+        };
 
-    var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
-    var attributeStatement = doc.documentElement.getElementsByTagName('saml:AttributeStatement');
-    assert.equal(attributeStatement.length, 0);
-  });
+        var signedAssertion = saml[createAssertion](options);
 
-  describe('encryption', function () {
+        assertSignature(signedAssertion, options);
 
-    it('should create a saml 2.0 signed and encrypted assertion', function (done) {
-      var options = {
-        cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem')
-      };
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var attributeStatement = doc.documentElement.getElementsByTagName('saml:AttributeStatement');
+        assert.equal(attributeStatement.length, 0);
+      });
 
-      saml.create(options, function(err, encrypted) {
-        if (err) return done(err);
+      describe('encryption', function () {
 
-        var encryptedData = utils.getEncryptedData(encrypted);
-        
-        xmlenc.decrypt(encryptedData.toString(), { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-          if (err) return done(err);
-          var isValid = utils.isValidSignature(decrypted, options.cert);
-          assert.equal(true, isValid);
-          done();
+        it('should create a saml 2.0 signed and encrypted assertion', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem')
+          };
+
+          saml[createAssertion](options, function (err, encrypted) {
+            if (err) return done(err);
+
+            var encryptedData = utils.getEncryptedData(encrypted);
+
+            xmlenc.decrypt(encryptedData.toString(), { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+              if (err) return done(err);
+              assertSignature(decrypted, options);
+              done();
+            });
+          });
+        });
+
+        it('should set attributes', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            attributes: {
+              'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
+              'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
+              'http://example.org/claims/testaccent': 'fóo', // should supports accents
+              'http://undefinedattribute/ws/com.com': undefined
+            }
+          };
+
+          saml[createAssertion](options, function (err, encrypted) {
+            if (err) return done(err);
+
+            var encryptedData = utils.getEncryptedData(encrypted);
+
+            xmlenc.decrypt(encryptedData.toString(), { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+              if (err) return done(err);
+
+              assertSignature(decrypted, options);
+
+              var attributes = utils.getAttributes(decrypted);
+              assert.equal(3, attributes.length);
+              assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
+              assert.equal('foo@bar.com', attributes[0].textContent);
+              assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
+              assert.equal('Foo Bar', attributes[1].textContent);
+              assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
+              assert.equal('fóo', attributes[2].textContent);
+
+              done();
+            });
+          });
         });
       });
     });
-
-    it('should set attributes', function (done) {
-      var options = {
-        cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        key: fs.readFileSync(__dirname + '/test-auth0.key'),
-        encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
-        encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem'),
-        attributes: {
-          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress': 'foo@bar.com',
-          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name': 'Foo Bar',
-          'http://example.org/claims/testaccent': 'fóo', // should supports accents
-          'http://undefinedattribute/ws/com.com': undefined
-        }
-      };
-
-      saml.create(options, function(err, encrypted) {
-        if (err) return done(err);
-
-        var encryptedData = utils.getEncryptedData(encrypted);
-        
-        xmlenc.decrypt(encryptedData.toString(), { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
-          if (err) return done(err);
-
-          var isValid = utils.isValidSignature(decrypted, options.cert);
-          assert.equal(true, isValid);
-
-          var attributes = utils.getAttributes(decrypted);
-          assert.equal(3, attributes.length);
-          assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-          assert.equal('foo@bar.com', attributes[0].textContent);
-          assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-          assert.equal('Foo Bar', attributes[1].textContent);
-          assert.equal('http://example.org/claims/testaccent', attributes[2].getAttribute('Name'));
-          assert.equal('fóo', attributes[2].textContent);
-
-          done();
-        });
-      });
-    });
-    
-  });
-
+  }
 });

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -27,7 +27,10 @@ describe('saml 2.0', function () {
     })
   });
 
-  function saml20TestSuite({ createAssertion, assertSignature }) {
+  function saml20TestSuite(options) {
+    var createAssertion = options.createAssertion;
+    var assertSignature = options.assertSignature;
+
     describe('#' + createAssertion, function () {
       it('whole thing with default authnContextClassRef', function () {
         var options = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,10 +1,13 @@
-var xmlCrypto = require('xml-crypto'),
-    crypto = require('crypto'),
-    xmldom = require('xmldom');
-    
+var xmlCrypto = require('xml-crypto');
+var xmldom = require('xmldom');
+
+/**
+ * @param {string} assertion
+ * @param {Buffer} cert
+ * @return {boolean}
+ */
 exports.isValidSignature = function(assertion, cert) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
-  var signature = xmlCrypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']")[0];
+  var signature = exports.getXmlSignatures(assertion)[0];
   var sig = new xmlCrypto.SignedXml(null, { idAttribute: 'AssertionID' });
   sig.keyInfoProvider = {
     getKeyInfo: function (key) {
@@ -17,6 +20,17 @@ exports.isValidSignature = function(assertion, cert) {
   sig.loadSignature(signature.toString());
   return sig.checkSignature(assertion);
 };
+
+/**
+ * @param {string} assertion
+ * @return {Element[]}
+ */
+exports.getXmlSignatures = function(assertion) {
+  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var signatures = xmlCrypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']");
+
+  return signatures;
+}
 
 exports.getIssuer = function(assertion) {
   var doc = new xmldom.DOMParser().parseFromString(assertion);


### PR DESCRIPTION
### Description

#### Allow unsigned SAML assertions
Adds a `#createUnsignedAssertion` function for both SAML 1.1 and SAML 2.0 that mirrors the existing `#create` but does not sign the created assertion. These may be used when signing the entire SAML response as opposed to signing assertions independently. This is a backward compatible change.

#### Significant refactor
There is a significant refactor under the hood in that I extracted the XML signing and encryption logic into their own modules and reused those modules across both saml10 and saml20 implementation. Previously, they were duplicated but very similar pieces of code.

#### Project hygiene
I've added `standard-version` and `commitlint` to make releases easier and to promote semver usage.

### Testing

I've updated all unit tests to test the signed + unsigned variants; the latter tests ensure that no signature is added. In addition, and 

#### Manual diff of SAML assertions

Apart from that, to ensure that there are no unexpected changes resulting from the refactor I've done a manual diff of the SAML payloads produced both prior to and before the refactor. There are no changes in the produced XML apart from message IDs and cryptographic (signatures, nonces, etc).

To perform this manual test we need to add some test code to log SAML responses. To do this, check out `master`, apply [0001-test-master-log-all-SAML-payloads-for-manual-compari.patch](https://gist.github.com/luuuis/1ca9f15d8436bfce1cb3b1456b0908af#file-0001-test-master-log-all-saml-payloads-for-manual-compari-patch) and run tests.
```
node-saml(master|…) % git am < 0001-test-master-log-all-SAML-payloads-for-manual-compari.patch 
Applying: test(master): log all SAML payloads for manual comparison
node-saml(master↑1|…) % mocha -R min test/ | tee master.txt
```

Then check out `allow-unsigned-assertions`, apply [0001-test-refactor-log-all-SAML-payloads-for-manual-compa.patch](https://gist.github.com/luuuis/1ca9f15d8436bfce1cb3b1456b0908af#file-0001-test-refactor-log-all-saml-payloads-for-manual-compa-patch) and run tests.
```
node-saml(allow-unsigned-assertions|…) % git am < 0001-test-refactor-log-all-SAML-payloads-for-manual-compa.patch
Applying: test(refactor): log all SAML payloads for manual comparison
node-saml(allow-unsigned-assertions↑1|…) % mocha -R min test/ | tee refactored.txt          
```

Diff the resulting files to see that the SAML assertions are equivalent.

![image](https://user-images.githubusercontent.com/161006/93072807-d5671600-f679-11ea-9886-21696f52d4c1.png)

The patches and resulting output are available in https://gist.github.com/luuuis/1ca9f15d8436bfce1cb3b1456b0908af.