### PR TITLE
fix(xml-encryption): bump up xml-encryption to 1.2.1

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -55,7 +55,7 @@ function extractSaml11Options(opts) {
  * @param [options.encryptionCert] {Buffer}
  * @param [options.encryptionPublicKey] {Buffer}
  * @param [options.encryptionAlgorithm] {string}
- * @param [options.keyEncryptionAlgorighm] {string}
+ * @param [options.keyEncryptionAlgorithm] {string}
  *
  * @param {Function} [callback] required if encrypting
  * @return {String|*}
@@ -88,7 +88,7 @@ exports.create = function(options, callback) {
  * @param [options.encryptionCert] {Buffer}
  * @param [options.encryptionPublicKey] {Buffer}
  * @param [options.encryptionAlgorithm] {string}
- * @param [options.keyEncryptionAlgorighm] {string}
+ * @param [options.keyEncryptionAlgorithm] {string}
  *
  * @param {Function} [callback] required if encrypting
  * @return {String|*}

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -94,7 +94,7 @@ function extractSaml20Options(opts) {
  * @param [options.encryptionCert] {Buffer}
  * @param [options.encryptionPublicKey] {Buffer}
  * @param [options.encryptionAlgorithm] {string}
- * @param [options.keyEncryptionAlgorighm] {string}
+ * @param [options.keyEncryptionAlgorithm] {string}
  *
  * @param {Function} [callback] required if encrypting
  * @return {*}
@@ -133,7 +133,7 @@ exports.create = function createSignedAssertion(options, callback) {
  * @param [options.encryptionCert] {Buffer}
  * @param [options.encryptionPublicKey] {Buffer}
  * @param [options.encryptionAlgorithm] {string}
- * @param [options.keyEncryptionAlgorighm] {string}
+ * @param [options.keyEncryptionAlgorithm] {string}
  *
  * @param {Function} [callback] required if encrypting
  * @return {*}

--- a/lib/xml/encrypt.js
+++ b/lib/xml/encrypt.js
@@ -10,7 +10,7 @@ exports.fromEncryptXmlOptions = function (options) {
       rsa_pub: options.encryptionPublicKey,
       pem: options.encryptionCert,
       encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-      keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
+      keyEncryptionAlgorithm: options.keyEncryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
     };
 
     // expose the encryptOptions as these are needed when adding the SubjectConfirmation

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "~1.0.1",
-    "xml-encryption": "0.11.2",
+    "xml-encryption": "^1.2.1",
     "xml-name-validator": "~2.0.1",
     "xmldom": "=0.1.15",
     "xpath": "0.0.5"


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Updates xml-encryption dependency version to resolve 'High' vulnerability found in node-forge

### References

https://github.com/auth0/node-saml/issues/67