### PR TITLE
feat: add external async signing and encryption strategies

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -57,17 +57,34 @@ function extractSaml11Options(opts) {
  * @param [options.encryptionAlgorithm] {string}
  * @param [options.keyEncryptionAlgorithm] {string}
  *
+ * @param [strategies]
+ *
+ * // Signing strategy
+ * @param {Function} [strategies.signXml]
+ *
+ * // Encryption strategy
+ * @param {Function} [strategies.encryptXml]
+ *
  * @param {Function} [callback] required if encrypting
  * @return {String|*}
  */
-exports.create = function(options, callback) {
-  return createAssertion(extractSaml11Options(options), {
+exports.create = function(options, strategies, callback) {
+  var defaultStrategy = {
     signXml: SignXml.fromSignXmlOptions(Object.assign({
       xpathToNodeBeforeSignature: "//*[local-name(.)='AuthenticationStatement']",
       signatureIdAttribute: 'AssertionID'
     }, options)),
     encryptXml: EncryptXml.fromEncryptXmlOptions(options)
-  }, callback);
+  }
+
+  if (typeof strategies === 'function' && callback == null) {
+    callback = strategies
+    strategies = defaultStrategy
+  } else {
+    strategies = strategies || defaultStrategy
+  }
+
+  return createAssertion(extractSaml11Options(options), strategies, callback);
 }
 
 /**
@@ -177,9 +194,19 @@ function createAssertion(options, strategies, callback) {
     nameIDs[1].setAttribute('Format', options.nameIdentifierFormat);
   }
 
+  if (callback) {
+    signAndEncryptAsync(doc, strategies, options, callback)
+  } else {
+    return signAndEncryptSync(doc, strategies)
+  }
+}
+
+function signAndEncryptAsync(doc, strategies, options, callback) {
   if (strategies.encryptXml === EncryptXml.unencrypted) {
-    var signed = strategies.signXml(doc);
-    return strategies.encryptXml(signed, callback);
+    strategies.signXml(doc, function(err, signed){
+      strategies.encryptXml(signed, callback);
+    });
+    return
   }
 
   // encryption is turned on,
@@ -204,6 +231,13 @@ function createAssertion(options, strategies, callback) {
     if (err) return callback(err);
     callback(null, result, proofSecret);
   });
+}
+
+function signAndEncryptSync(doc, strategies) {
+  if (strategies.encryptXml === EncryptXml.unencrypted) {
+    var signed = strategies.signXml(doc);
+    return strategies.encryptXml(signed);
+  }
 }
 
 function addSubjectConfirmation(encryptOptions, doc, randomBytes, callback) {

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -96,17 +96,34 @@ function extractSaml20Options(opts) {
  * @param [options.encryptionAlgorithm] {string}
  * @param [options.keyEncryptionAlgorithm] {string}
  *
+ * @param [strategies]
+ *
+ * // Signing strategy
+ * @param {Function} [strategies.signXml]
+ *
+ * // Encryption strategy
+ * @param {Function} [strategies.encryptXml]
+ *
  * @param {Function} [callback] required if encrypting
  * @return {*}
  */
-exports.create = function createSignedAssertion(options, callback) {
-  return createAssertion(extractSaml20Options(options), {
+exports.create = function createSignedAssertion(options, strategies, callback) {
+  var defaultStrategy = {
     signXml: SignXml.fromSignXmlOptions(Object.assign({
       xpathToNodeBeforeSignature: "//*[local-name(.)='Issuer']",
       signatureIdAttribute: 'ID'
     }, options)),
     encryptXml: EncryptXml.fromEncryptXmlOptions(options)
-  }, callback);
+  }
+
+  if (typeof strategies === 'function' && callback == null) {
+    callback = strategies
+    strategies = defaultStrategy
+  } else {
+    strategies = strategies || defaultStrategy
+  }
+
+  return createAssertion(extractSaml20Options(options), strategies, callback);
 };
 
 /**
@@ -251,6 +268,40 @@ function createAssertion(options, strategies, callback) {
     authnCtxClassRef.textContent = options.authnContextClassRef;
   }
 
+  if (callback) {
+    signAndEncryptAsync(doc, strategies, callback)
+  } else {
+    return signAndEncryptSync(doc, strategies)
+  }
+}
+
+function signAndEncryptAsync(doc, strategies, callback) {
+  try {
+    strategies.signXml(doc, function(err, signed){
+      if (err || !signed) {
+        return utils.reportError(err, callback);
+      }
+
+      if (strategies.encryptXml === EncryptXml.unencrypted) {
+        return strategies.encryptXml(signed, callback);
+      }
+
+      async.waterfall([
+        function (cb) {
+          strategies.encryptXml(signed, cb)
+        },
+        function (encrypted, cb) {
+          var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+          cb(null, utils.removeWhitespace(assertion));
+        },
+      ], callback);
+    });
+  } catch(err) {
+    utils.reportError(err, callback);
+  }
+}
+
+function signAndEncryptSync(doc, strategies) {
   var signed;
   try {
     signed = strategies.signXml(doc);
@@ -259,16 +310,6 @@ function createAssertion(options, strategies, callback) {
   }
 
   if (strategies.encryptXml === EncryptXml.unencrypted) {
-    return strategies.encryptXml(signed, callback);
+    return strategies.encryptXml(signed);
   }
-
-  async.waterfall([
-    function (cb) {
-      strategies.encryptXml(signed, cb)
-    },
-    function (encrypted, cb) {
-      var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-      cb(null, utils.removeWhitespace(assertion));
-    },
-  ], callback);
 }

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -7,6 +7,8 @@ var xmldom = require('xmldom');
 var xmlenc = require('xml-encryption');
 
 var saml = require('../lib/saml20');
+var EncryptXml = require('../lib/xml/encrypt');
+var SignXml = require('../lib/xml/sign');
 
 describe('saml 2.0', function () {
   saml20TestSuite({
@@ -511,6 +513,40 @@ describe('saml 2.0', function () {
               done();
             });
           });
+        });
+
+        it('should create a saml 2.0 signed and encrypted assertion with async strategy', function (done) {
+          var options = {
+            cert: fs.readFileSync(__dirname + '/test-auth0.pem'),
+            key: fs.readFileSync(__dirname + '/test-auth0.key'),
+            encryptionPublicKey: fs.readFileSync(__dirname + '/test-auth0_rsa.pub'),
+            encryptionCert: fs.readFileSync(__dirname + '/test-auth0.pem')
+          };
+
+          var strategies = {
+            signXml: SignXml.fromSignXmlOptions(Object.assign({
+              xpathToNodeBeforeSignature: "//*[local-name(.)='Issuer']",
+              signatureIdAttribute: 'ID'
+            }, options)),
+            encryptXml: EncryptXml.fromEncryptXmlOptions(options)
+          }
+
+          var callback = function(err, encrypted){
+            if (err) return done(err);
+            var encryptedData = utils.getEncryptedData(encrypted);
+
+            xmlenc.decrypt(encryptedData.toString(), { key: fs.readFileSync(__dirname + '/test-auth0.key') }, function (err, decrypted) {
+              if (err) return done(err);
+              assertSignature(decrypted, options);
+              done();
+            });
+          }
+
+          if (createAssertion === 'create'){
+            saml[createAssertion](options, strategies, callback)
+          } else {
+            saml[createAssertion](options, callback)
+          }
         });
 
         it('should set attributes', function (done) {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Allow the user of the library to specify a signing or encryption strategy externally. Useful when signing keys are in remote servers or HSM devices and signing must happen async.

### Testing

- [ x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ x ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ x ] All active GitHub checks for tests, formatting, and security are passing
- [ x ] The correct base branch is being used, if not `master`
