### PR TITLE
Update npm modules - primarily to pull in latest xmldom

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "saml",
   "version": "1.0.0",
   "devDependencies": {
-    "@commitlint/cli": "^11.0.0",
-    "@commitlint/config-conventional": "^11.0.0",
+    "@commitlint/cli": "^12.1.4",
+    "@commitlint/config-conventional": "^12.1.4",
     "chai": "^4.2.0",
-    "husky": "^4.3.0",
-    "mocha": "^8.2.0",
-    "should": "~1.2.1",
+    "husky": "^6.0.0",
+    "mocha": "^9.0.0",
+    "should": "^13.2.3",
     "standard-version": "^9.0.0"
   },
   "main": "./lib",
@@ -19,14 +19,14 @@
   "author": "Matias Woloski (Auth0)",
   "license": "MIT",
   "dependencies": {
-    "async": "~0.2.9",
-    "moment": "2.19.3",
+    "async": "^3.2.0",
+    "moment": "^2.29.1",
     "valid-url": "~1.0.9",
-    "xml-crypto": "2.0.0",
+    "xml-crypto": "^2.1.2",
     "xml-encryption": "^1.2.1",
-    "xml-name-validator": "~2.0.1",
-    "xmldom": "0.1.17",
-    "xpath": "0.0.5"
+    "xml-name-validator": "^3.0.0",
+    "xmldom": "^0.6.0",
+    "xpath": "0.0.32"
   },
   "scripts": {
     "release": "standard-version",


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

Update npm modules to latest versions. Primarily to pull in latest xmldom. Old xmldom is subject to CVE-2021-21366 which is fixed in xmldom 0.5.0. This PR pulls in 0.6.0

### References
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21366
https://nvd.nist.gov/vuln/detail/CVE-2021-21366
https://github.com/xmldom/xmldom/releases/tag/0.5.0

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [N/A ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [N/A ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X ] All active GitHub checks for tests, formatting, and security are passing
- [ X] The correct base branch is being used, if not `master`
