### PR TITLE
fix: update xmldom and xml-crypto to fix security issues

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -1,6 +1,6 @@
 var path = require('path');
 var utils = require('./utils');
-var Parser = require('xmldom').DOMParser;
+var Parser = require('@xmldom/xmldom').DOMParser;
 var xmlenc = require('xml-encryption');
 var moment = require('moment');
 var async = require('async');
@@ -120,7 +120,7 @@ function createAssertion(options, strategies, callback) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
-  
+
   if (options.audiences) {
     var audiences = options.audiences instanceof Array ? options.audiences : [options.audiences];
     audiences.forEach(function (audience) {
@@ -135,7 +135,7 @@ function createAssertion(options, strategies, callback) {
     var statement = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'AttributeStatement')[0];
     Object.keys(options.attributes).forEach(function(prop) {
       if(typeof options.attributes[prop] === 'undefined') return;
-      
+
       // <saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/claims/identity">
       //    <saml:AttributeValue>Foo Bar</saml:AttributeValue>
       // </saml:Attribute>
@@ -162,15 +162,15 @@ function createAssertion(options, strategies, callback) {
     .setAttribute('AuthenticationInstant', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
 
   var nameID = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameIdentifier')[0];
-  
+
   if (options.nameIdentifier) {
     nameID.textContent = options.nameIdentifier;
-  
+
     doc.getElementsByTagName('saml:AuthenticationStatement')[0]
       .getElementsByTagName('saml:NameIdentifier')[0]
       .textContent = options.nameIdentifier;
   }
-  
+
   if (options.nameIdentifierFormat) {
     var nameIDs = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameIdentifier');
     nameIDs[0].setAttribute('Format', options.nameIdentifierFormat);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 var fs = require('fs');
-var Parser = require('xmldom').DOMParser;
+var Parser = require('@xmldom/xmldom').DOMParser;
 
 exports.pemToCert = function(pem) {
   var cert = /-----BEGIN CERTIFICATE-----([^-]*)-----END CERTIFICATE-----/g.exec(pem.toString());

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "author": "Matias Woloski (Auth0)",
   "license": "MIT",
   "dependencies": {
+    "@xmldom/xmldom": "^0.7.4",
     "async": "~0.2.9",
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
-    "xml-crypto": "2.0.0",
+    "xml-crypto": "^2.1.3",
     "xml-encryption": "^1.2.1",
     "xml-name-validator": "~2.0.1",
-    "xmldom": "0.1.17",
     "xpath": "0.0.5"
   },
   "scripts": {

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -2,7 +2,7 @@ var assert = require('chai').assert;
 var fs = require('fs');
 var moment = require('moment');
 var should = require('should');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 var xmlenc = require('xml-encryption');
 
 var utils = require('./utils');
@@ -27,7 +27,7 @@ describe('saml 1.1', function () {
       it: it.skip
     })
   });
-  
+
   function saml11TestSuite(options) {
     var createAssertion = options.createAssertion;
     var assertSignature = options.assertSignature;

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var utils = require('./utils');
 var moment = require('moment');
 var should = require('should');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 var xmlenc = require('xml-encryption');
 
 var saml = require('../lib/saml20');

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,5 @@
 var xmlCrypto = require('xml-crypto');
-var xmldom = require('xmldom');
+var xmldom = require('@xmldom/xmldom');
 
 /**
  * @param {string} assertion


### PR DESCRIPTION
### Description

Dependency updates to fix `npm audit` report.

**Update from `xmldom@0.1.17` to `@xmldom/xmldom:^0.7.4`**
* See [xmldom changelog](https://github.com/xmldom/xmldom/blob/master/CHANGELOG.md). (NPM package has been moved, is still the same repo, but has changed maintainers since v0.1.17).
* Fixes security vulnerabilities https://github.com/xmldom/xmldom/security/advisories/GHSA-5fg8-2547-mr8q and https://github.com/xmldom/xmldom/security/advisories/GHSA-h6q6-9hqw-rwfv. 
* Also has some breaking changes - I don't believe should impact us here, as we don't parse arbitrary user input.

**Update `xml-crypto` from `2.0.0` to `^2.1.3`**
* See [xml-crypto changelog](https://github.com/yaronn/xml-crypto/releases)
* Updates `xmldom` dependency to `^0.7.0` (to fix the above two vulnerabilities)

**General notes**
I've not listed this as a breaking change - have created this as a `fix`, so we'll release this as a patch version (1.0.1). Although we're introducing breaking changes in dependencies, I don't believe this constitutes a breaking change.

I've updated the dependency ranges to include minor version upgrades (ie adding a `^`) rather than fixing a version. This will allow us to pull in future dependency security upgrades into `node-samlp` without needing to release a new `node-saml` version again.

Feedback / disagreement on both the above points is welcome :)

### Testing
Unit tests have succeeded here and in the `node-samlp` library updated to use these changes, and have done some manual testing using `node-samlp`.

I've also verified that there are no differences in the SAML assertions produced, using the steps taken from https://github.com/auth0/node-saml/pull/66. There are no changes in the SAML assertions produced in the unit tests, aside from message IDs and crytographic values.

For reference - the following patch was applied to the code to log the SAML responses in each test: https://gist.github.com/CharlesRea/cdddd37ffb5981697d2928e7f1b8c2e4#file-0-node-saml-assertion-logging-patch. The tests were run with these changes on the master branch, and in the PR branch.

Commands used to apply & run tests:
```
$ git am < 0-node-saml-assertion-logging.patch
$ mocha -R min test/ | tee master.txt
```
Then the output files were diffed to see there were no differences introduced by this change (output is in the linked gist for reference).