### PR TITLE
fix(saml11): do not mutate moment() when `options.lifetimeInSeconds` is provided

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -118,7 +118,7 @@ function createAssertion(options, strategies, callback) {
 
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-    conditions[0].setAttribute('NotOnOrAfter', now.add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+    conditions[0].setAttribute('NotOnOrAfter', moment(now).add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
 
   if (options.audiences) {

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -95,10 +95,13 @@ describe('saml 1.1', function () {
         var signedAssertion = saml11[createAssertion](options);
         var conditions = utils.getConditions(signedAssertion);
         assert.equal(1, conditions.length);
+        var authenticationInstant = utils.getAuthenticationInstant(signedAssertion);
         var notBefore = conditions[0].getAttribute('NotBefore');
         var notOnOrAfter = conditions[0].getAttribute('NotOnOrAfter');
+
         should.ok(notBefore);
         should.ok(notOnOrAfter);
+        should.equal(authenticationInstant, notBefore);
 
         var lifetime = Math.round((moment(notOnOrAfter).utc() - moment(notBefore).utc()) / 1000);
         assert.equal(600, lifetime);

--- a/test/utils.js
+++ b/test/utils.js
@@ -47,6 +47,10 @@ exports.getIssueInstant = function(assertion) {
   return doc.documentElement.getAttribute('IssueInstant');
 };
 
+exports.getAuthenticationInstant = function (assertion) {
+  return exports.getAuthenticationStatement(assertion).getAttribute('AuthenticationInstant');
+};
+
 exports.getConditions = function(assertion) {
   var doc = new xmldom.DOMParser().parseFromString(assertion);
   return doc.documentElement.getElementsByTagName('saml:Conditions');


### PR DESCRIPTION
Don't mutate the `moment` instance while generating the `NotOnOrAfter`, which causes the `AuthenticationInstant` to be incorrect.

Fixes #32.