### PR TITLE
fix: remove vulnerable node-forge dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "^2.1.3",
-    "xml-encryption": "^1.2.1",
+    "xml-encryption": "^2.0.0",
     "xml-name-validator": "~2.0.1",
     "xpath": "0.0.5"
   },


### PR DESCRIPTION
### Description

Upgraded the xml-encryption package which removes the vulnerable node-forge dependency

### References
https://github.com/advisories/GHSA-8fr3-hfg3-gpgp

### Testing

All existing tests pass

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
