### PR TITLE
fix!: remove vulnerable node-forge dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Create SAML assertions. Supports SAML 1.1 and SAML 2.0 tokens.
 
 [![Build Status](https://travis-ci.org/auth0/node-saml.png)](https://travis-ci.org/auth0/node-saml)
 
+### Supported Node Versions
+
+node >= 12
+
 ### Usage
 
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "saml",
   "version": "1.0.1",
+  "engines": {
+    "node": ">=12"
+  },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
@@ -24,7 +27,7 @@
     "moment": "2.19.3",
     "valid-url": "~1.0.9",
     "xml-crypto": "^2.1.3",
-    "xml-encryption": "^1.2.1",
+    "xml-encryption": "^2.0.0",
     "xml-name-validator": "~2.0.1",
     "xpath": "0.0.5"
   },


### PR DESCRIPTION
### Description

Upgraded the xml-encryption package which removes the vulnerable node-forge dependency

### References
https://github.com/advisories/GHSA-8fr3-hfg3-gpgp

### Testing

All existing tests pass

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
