### PR TITLE
ci: add GITHUB_TOKEN to prepare-release version detection step

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Detect Next Version
         id: version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run semantic-release with only commit analyzer to detect version
           NEXT_VERSION=$(npx semantic-release --dry-run --plugins @semantic-release/commit-analyzer | tee /dev/stderr | awk '/The next release version is/{print $NF}')


### PR DESCRIPTION
By submitting a PR to this repository, I agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Detect Next Version step in prepare-release.yml workflow is [failing](https://github.com/auth0/node-saml/actions/runs/22960015318/job/66647641577#step:5:27) due to missing permissions
 
To fix the issue, this PR adds GITHUB TOKEN to step env.

### References

https://github.com/auth0/node-saml/pull/106

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
