### PR TITLE
ci: fix release workflow

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@commitlint/config-conventional"]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release
     if: startsWith(github.event.head_commit.message, 'chore(release):')
 
     steps:
@@ -36,6 +35,10 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
+
+      - name: Install Python dependencies
+        shell: bash
+        run: pip install boto3>=1.34.159 requests>=2.32.3 rl-deploy>=2.2.3.0 pip-system-certs>=4.0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
     [
       "@semantic-release/exec",
       {
-        "verifyReleaseCmd": "ARTIFACT=$(npm pack --ignore-scripts | tail -1) && rl-wrapper --artifact \"$ARTIFACT\" --name node-saml --version ${nextRelease.version} --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --build-env github_actions --suppress_output",
+        "verifyReleaseCmd": "ARTIFACT=\"$(pwd)/$(npm pack --ignore-scripts | tail -1)\" && rl-wrapper --artifact \"$ARTIFACT\" --name node-saml --version ${nextRelease.version} --repository $GITHUB_REPOSITORY --commit $GITHUB_SHA --build-env github_actions --suppress-output",
         "prepareCmd": "git diff --exit-code"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "semantic-release": "^25.0.2",
     "should": "~1.2.1"
   },
+  "files": [
+    "lib"
+  ],
   "main": "./lib",
   "repository": "https://github.com/auth0/node-saml",
   "keywords": [


### PR DESCRIPTION
### Description

- Fixed `verifyReleaseCmd` in `.releaserc.json` to use an absolute artifact path and correct `--suppress-output` flag.
- Removed `environment: release` from `release.yml` job to align with trust policy expected subject.
- Added missing `Install Python dependencies` step in `release.yml` to ensure `rl-wrapper` dependencies are available before scanning
- Add `files` configuration to package.json to specify files to be distributed.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
