### PR TITLE
fix(deps): update @xmldom/xmldom to ^0.9.10 for spec-compliant DOM

### DIFF
--- a/lib/saml11.js
+++ b/lib/saml11.js
@@ -218,7 +218,7 @@ function addSubjectConfirmation(encryptOptions, doc, randomBytes, callback) {
     for (var i=0; i<subjectConfirmationNodes.length; i++) {
       var keyinfoDom;
       try {
-        keyinfoDom = new Parser().parseFromString(keyinfo);
+        keyinfoDom = new Parser().parseFromString(keyinfo, 'text/xml');
       } catch(error){
         return utils.reportError(error, callback);
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,7 +69,7 @@ function getRandomInt(min, max) {
  */
 exports.factoryForNode = function factoryForNode(pathToTemplate) {
   const template = fs.readFileSync(pathToTemplate);
-  const prototypeDoc = new Parser().parseFromString(template.toString());
+  const prototypeDoc = new Parser().parseFromString(template.toString(), 'text/xml');
 
   return function () {
     return prototypeDoc.cloneNode(true);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Matias Woloski (Auth0)",
   "license": "MIT",
   "dependencies": {
-    "@xmldom/xmldom": "^0.7.4",
+    "@xmldom/xmldom": "^0.9.10",
     "async": "^3.2.4",
     "moment": "^2.29.4",
     "valid-url": "~1.0.9",

--- a/test/saml11.tests.js
+++ b/test/saml11.tests.js
@@ -304,7 +304,7 @@ describe('saml 1.1', function () {
           xpathToNodeBeforeSignature: "//*[local-name(.)='Conditions']"
         };
         var signedAssertion = saml11[createAssertion](options);
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
 
         var signature = doc.documentElement.getElementsByTagName('Signature');
 
@@ -438,7 +438,7 @@ describe('saml 1.1', function () {
             xmlenc.decrypt(encrypted, { key: fs.readFileSync(__dirname + '/test-auth0.key')}, function(err, decrypted) {
               if (err) return done(err);
 
-              var doc = new xmldom.DOMParser().parseFromString(decrypted);
+              var doc = new xmldom.DOMParser().parseFromString(decrypted, 'text/xml');
               var subjectConfirmationNodes = doc.documentElement.getElementsByTagName('saml:SubjectConfirmation');
               assert.equal(2, subjectConfirmationNodes.length);
               for (var i=0;i<subjectConfirmationNodes.length;i++) {
@@ -503,7 +503,7 @@ describe('saml 1.1', function () {
 
           saml11[createAssertion](options, function (err, encrypted) {
             if (err) return done(err);
-            var doc = new xmldom.DOMParser().parseFromString(encrypted);
+            var doc = new xmldom.DOMParser().parseFromString(encrypted, 'text/xml');
             var encryptionMethod = doc.getElementsByTagName('xenc:EncryptionMethod')[0];
             assert.equal('http://www.w3.org/2009/xmlenc11#aes256-gcm', encryptionMethod.getAttribute('Algorithm'));
             done();
@@ -523,7 +523,7 @@ describe('saml 1.1', function () {
 
           saml11[createAssertion](options, function (err, encrypted) {
             if (err) return done(err);
-            var doc = new xmldom.DOMParser().parseFromString(encrypted);
+            var doc = new xmldom.DOMParser().parseFromString(encrypted, 'text/xml');
             var encryptionMethod = doc.getElementsByTagName('xenc:EncryptionMethod')[0];
             assert.equal('http://www.w3.org/2001/04/xmlenc#aes256-cbc', encryptionMethod.getAttribute('Algorithm'));
             assert.equal(consoleSpy.called, true);

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -337,19 +337,19 @@ describe('saml 2.0', function () {
         var attributes = utils.getAttributes(signedAssertion);
         assert.equal(5, attributes.length);
         assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress', attributes[0].getAttribute('Name'));
-        assert.equal('', attributes[0].getAttribute('NameFormat'));
+        assert.equal(null, attributes[0].getAttribute('NameFormat'));
         assert.equal('foo@bar.com', attributes[0].textContent);
         assert.equal('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name', attributes[1].getAttribute('Name'));
-        assert.equal('', attributes[1].getAttribute('NameFormat'));
+        assert.equal(null, attributes[1].getAttribute('NameFormat'));
         assert.equal('Foo Bar', attributes[1].textContent);
         assert.equal('testaccent', attributes[2].getAttribute('Name'));
-        assert.equal('', attributes[2].getAttribute('NameFormat'));
+        assert.equal(null, attributes[2].getAttribute('NameFormat'));
         assert.equal('fóo', attributes[2].textContent);
         assert.equal('urn:test:1:2:3', attributes[3].getAttribute('Name'));
-        assert.equal('', attributes[3].getAttribute('NameFormat'));
+        assert.equal(null, attributes[3].getAttribute('NameFormat'));
         assert.equal('true', attributes[3].textContent);
         assert.equal('123~oo', attributes[4].getAttribute('Name'));
-        assert.equal('', attributes[4].getAttribute('NameFormat'));
+        assert.equal(null, attributes[4].getAttribute('NameFormat'));
         assert.equal('123', attributes[4].textContent);
       });
 
@@ -461,7 +461,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var signature = doc.documentElement.getElementsByTagName('Signature');
 
         assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
@@ -486,7 +486,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var signature = doc.documentElement.getElementsByTagName(options.signatureNamespacePrefix + ':Signature');
         assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
       });
@@ -510,7 +510,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var signature = doc.documentElement.getElementsByTagName(options.prefix + ':Signature');
         assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
       });
@@ -534,7 +534,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var signature = doc.documentElement.getElementsByTagName('Signature');
         assert.equal('saml:Conditions', signature[0].previousSibling.nodeName);
       });
@@ -559,7 +559,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var audienceRestriction = doc.documentElement.getElementsByTagName('saml:AudienceRestriction');
         assert.equal(audienceRestriction.length, 0);
       });
@@ -576,7 +576,7 @@ describe('saml 2.0', function () {
 
         assertSignature(signedAssertion, options);
 
-        var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+        var doc = new xmldom.DOMParser().parseFromString(signedAssertion, 'text/xml');
         var attributeStatement = doc.documentElement.getElementsByTagName('saml:AttributeStatement');
         assert.equal(attributeStatement.length, 0);
       });

--- a/test/utils.js
+++ b/test/utils.js
@@ -26,24 +26,24 @@ exports.isValidSignature = function(assertion, cert) {
  * @return {Element[]}
  */
 exports.getXmlSignatures = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   var signatures = xmlCrypto.xpath(doc, "/*/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']");
 
   return signatures;
 }
 
 exports.getIssuer = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement.getAttribute('Issuer');
 };
 
 exports.getAssertionID = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement.getAttribute('AssertionID');
 };
 
 exports.getIssueInstant = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement.getAttribute('IssueInstant');
 };
 
@@ -52,12 +52,12 @@ exports.getAuthenticationInstant = function (assertion) {
 };
 
 exports.getConditions = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement.getElementsByTagName('saml:Conditions');
 };
 
 exports.getAudiences = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:Conditions')[0]
             .getElementsByTagName('saml:AudienceRestrictionCondition')[0]
@@ -65,19 +65,19 @@ exports.getAudiences = function(assertion) {
 };
 
 exports.getAuthenticationStatement = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:AuthenticationStatement')[0];
 };
 
 exports.getAttributes = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:Attribute');
 };
 
 exports.getNameIdentifier = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:NameIdentifier')[0];
 };
@@ -86,31 +86,31 @@ exports.getNameIdentifier = function(assertion) {
 //SAML2.0
 
 exports.getNameID = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:NameID')[0];
 };
 
 exports.getSaml2Issuer = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:Issuer')[0];
 };
 
 exports.getAuthnContextClassRef = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:AuthnContextClassRef')[0];
 };
 
 exports.getSubjectConfirmation = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  var doc = new xmldom.DOMParser().parseFromString(assertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('saml:getSubjectConfirmation');
 };
 
 exports.getEncryptedData = function(encryptedAssertion) {
-  var doc = new xmldom.DOMParser().parseFromString(encryptedAssertion);
+  var doc = new xmldom.DOMParser().parseFromString(encryptedAssertion, 'text/xml');
   return doc.documentElement
             .getElementsByTagName('xenc:EncryptedData')[0];
 };


### PR DESCRIPTION
## Summary

Bumps `@xmldom/xmldom` from `^0.7.4` to `^0.9.10` and adapts the call sites to its spec-compliant API. Tests still pass (105 / 5 pending — same as baseline).

Closes #115. (Also addresses the goal of #101 — bumping out of the 0.7.x CVE floor — but goes the whole way to current `latest` rather than stopping at 0.8 LTS.)

## Why now

- `@xmldom/xmldom@<0.8.12` has a known XML-injection vulnerability ([GHSA-wh4c-j3r5-mjhp](https://github.com/advisories/GHSA-wh4c-j3r5-mjhp), CVE-2026-34601). Snyk and Dependabot flag this for every consumer of `saml@4.0.0`. Most downstream projects work around it with package-manager overrides.
- npm's `latest` dist-tag for `@xmldom/xmldom` is now `0.9.10`. When downstream overrides are open-ended (`>=0.8.12` etc.), a fresh resolution promotes through to 0.9.x and breaks `saml` at runtime — see [#115](https://github.com/auth0/node-saml/issues/115).
- The pre-existing Snyk PR #101 (`0.7.13` → `0.8.10`) has been open and unmerged for ~2 years. This PR supersedes it and goes one major further so we don't have to revisit when 0.10 ships.

## What changed

`@xmldom/xmldom@0.9.0` made two intentional, spec-aligning changes that touch this library:

### 1. `DOMParser.parseFromString()` requires a mimeType

Old behavior: `parseFromString(xml)` parsed as XML by default.
New behavior: throws `TypeError: ... mimeType "undefined" is not valid` when called without a mimeType.

Fixed in 26 call sites by passing `'text/xml'`:

- `lib/saml11.js:221` (1 site, production)
- `lib/utils.js:72` (1 site, production)
- `test/saml11.tests.js` (4 sites)
- `test/saml20.tests.js` (6 sites)
- `test/utils.js` (14 sites)

### 2. `Element.getAttribute()` returns `null` for missing attributes

Old behavior: returned `''` (non-spec).
New behavior: returns `null`, matching the [DOM Living Standard](https://dom.spec.whatwg.org/#dom-element-getattribute).

The only test that depended on the old behavior — `saml 2.0 #create / should not set NameFormat in attributes when includeAttributeNameFormat is false` ([test/saml20.tests.js:316](https://github.com/auth0/node-saml/blob/master/test/saml20.tests.js#L316)) — has been updated to expect `null`. (The corresponding `#createUnsignedAssertion` run shares the same `it` block, so both pass with the single change.)

No production code depended on the old behavior.

## Test plan

\`\`\`
$ npm install
$ npm test
...
  105 passing (261ms)
  5 pending
\`\`\`

Same counts as on `master` before the bump.

## Notes for reviewers

- I am not a regular contributor to this repo — opened this PR after a downstream project ([ProdigyEMS/prodigy](https://github.com/ProdigyEMS/prodigy)) hit the 0.9.x compat break via Renovate's `lockFileMaintenance`. Happy to iterate if there's a preferred shape (e.g. capping at `^0.8.0` LTS instead of jumping to `^0.9.10`, or splitting the dep bump from the test fix).
- Did not touch `xml-crypto` (`^2.1.3`) or `xml-encryption` (`^4.0.0`) — both have newer majors but those are separate concerns.
- No CHANGELOG.md exists; if the project uses semantic-release (`semantic-release` is in devDeps), the conventional-commit subject should drive the changelog automatically.

[Written by Claude]