### PR TITLE
ci: replace npx changelog call with npm script and fix prepare-release workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -38,7 +38,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Run semantic-release with dry-run to detect version
-          NEXT_VERSION=$(npx semantic-release --dry-run --verify-conditions false | tee /dev/stderr | awk '/The next release version is/{print $NF}')
+          set -o pipefail
+          if ! OUTPUT=$(npx semantic-release --dry-run --verify-conditions false --verify-release false 2>&1); then
+            echo "$OUTPUT"
+            echo "::error::semantic-release failed during version detection"
+            exit 1
+          fi
+          echo "$OUTPUT"
+          NEXT_VERSION=$(echo "$OUTPUT" | awk '/The next release version is/{print $NF}')
           echo "next=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Update package.json
@@ -49,7 +56,7 @@ jobs:
 
       - name: Update CHANGELOG.md
         if: steps.version.outputs.next != ''
-        run: npx conventional-changelog-cli -p conventionalcommits -i CHANGELOG.md -s
+        run: npm run update-changelog
 
       - name: Create Pull Request
         if: steps.version.outputs.next != ''

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@commitlint/cli": "^20.3.1",
     "@commitlint/config-conventional": "^20.3.1",
     "@semantic-release/exec": "^7.0.3",
+    "conventional-changelog": "^7.2.1",
     "conventional-changelog-conventionalcommits": "^9.3.0",
     "chai": "^4.2.0",
     "husky": "^9.1.7",
@@ -39,6 +40,7 @@
   },
   "scripts": {
     "prepare": "husky",
-    "test": "mocha"
+    "test": "mocha",
+    "update-changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md"
   }
 }


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fixes the `Prepare Release` workflow, two bugs introduced by https://github.com/auth0/node-saml/pull/112, and hardens changelog generation for reproducibility.

The `Detect Next Version` step ran `semantic-release --dry-run --verify-conditions false`. That flag only skips the `verifyConditions` step. The `verifyRelease` step still executed the `@semantic-release/exec` plugin's `verifyReleaseCmd`, which runs `npm pack` and then `rl-wrapper`. As a result:

- **`rl-wrapper: not found`** : that binary is only installed in`release.yml`, not `prepare-release.yml`, so the step fails.
- **A stray `.tgz` in the release PR** : `npm pack` leaves `*.tgz` in the workspace, which `create-pull-request` then commits into the release PR.

This PR fixes both issues by adding `--verify-release false` so the dry-run only runs `analyzeCommits` (still using the `conventionalcommits` preset from `.releaserc.json`), and never triggers `npm pack` / `rl-wrapper`.


This PR also updates changelog generation to avoid runtime package resolution in CI:

- Adds a local changelog script in `package.json`
- Pins maintained changelog tooling in `package.json`
- Replaces direct `npx changelog` invocation in `prepare-release` workflow with `npm run update-changelog`


### Testing

Ran the dry-run command locally and verified that:

- Version detection works: `The next release version is x.y.z` is printed and captured by the `awk` pipeline.
- No `.tgz` is created.
- No `rl-wrapper` invocation.
- Changelog update runs via `npm run update-changelog` using local project dependencies.